### PR TITLE
Use environment variables for Supabase client configuration

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,8 +1,11 @@
 // lib/supabaseClient.ts
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://grjycoovcdjapnpbrgao.supabase.co';
-const supabaseAnonKey =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdyanljb292Y2RqYXBucGJyZ2FvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3OTY1MjMsImV4cCI6MjA2OTM3MjUyM30.M8ewcmp--gVDIbaVjybvScrF7ck74swFAA_LEWf12x8';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase environment variables are not set.');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- read the Supabase URL and anon key from public environment variables
- throw a clear error when the required Supabase environment variables are missing
- export the Supabase client created with the configured values

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c90fb7f8e4832d9d4fa5d1abc6ebd9