### PR TITLE
Update script types with new schema fields

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/types/db.ts
+++ b/types/db.ts
@@ -15,9 +15,11 @@ export interface Script {
   id: string;
   title: string;
   genre: string;
-  length: number | null;
-  synopsis?: string | null;
-  user_id: string; // senaryo sahibi (writer)
+  length: number;
+  synopsis: string;
+  description: string;
+  price_cents: number;
+  owner_id: string; // senaryo sahibi (writer)
   created_at: string; // ISO
 }
 
@@ -58,6 +60,11 @@ export interface Suggestion {
 export interface ApplicationWithJoins {
   id: string;
   status: ApplicationStatus | string;
-  script: Pick<Script, 'id' | 'title' | 'genre' | 'length'> | null;
+  script:
+    | Pick<
+        Script,
+        'id' | 'title' | 'genre' | 'length' | 'synopsis' | 'description' | 'price_cents' | 'owner_id'
+      >
+    | null;
   writer: Pick<User, 'id' | 'email'> | null;
 }


### PR DESCRIPTION
## Summary
- align the Script interface with the latest schema by renaming `user_id` to `owner_id` and adding `description` and `price_cents`
- make `length` and `synopsis` required to reflect their non-nullable schema definitions
- expand `ApplicationWithJoins` to expose the newly required Script fields and include the generated Next.js TypeScript environment declarations

## Testing
- npm run lint *(fails: pre-existing lint rule violations in dashboard and how-it-works pages)*

------
https://chatgpt.com/codex/tasks/task_e_68c912b1b454832d9cdbdbeb989697d8