### PR TITLE
Add length and price to producer script detail

### DIFF
--- a/app/dashboard/producer/browse/[id]/page.tsx
+++ b/app/dashboard/producer/browse/[id]/page.tsx
@@ -17,7 +17,7 @@ export default function ScriptDetailPage() {
   const fetchScript = async () => {
     const { data, error } = await supabase
       .from('scripts')
-      .select('*')
+      .select('id, title, genre, length, price_cents, description')
       .eq('id', id)
       .single();
 
@@ -37,7 +37,8 @@ export default function ScriptDetailPage() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">🎬 {script.title}</h1>
       <p className="text-sm text-[#7a5c36]">
-        Tür: {script.genre} &middot; Süre: {script.duration}
+        Tür: {script.genre} &middot; Süre: {script.length} &middot; Fiyat: ₺
+        {(script.price_cents / 100).toFixed(2)}
       </p>
 
       <div className="bg-white rounded-xl shadow p-6 border-l-4 border-[#f9c74f] space-y-4">


### PR DESCRIPTION
## Summary
- query script length and price fields when loading a producer script
- show the script length and formatted TL price alongside genre information

## Testing
- npm run lint *(fails: existing lint warnings and an error in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c912b2d7b8832dab5c920b2d1831bc