### PR TITLE
Add description and pricing controls to writer script forms

### DIFF
--- a/app/dashboard/writer/scripts/edit/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 
@@ -11,14 +11,14 @@ export default function EditScriptPage() {
   const [title, setTitle] = useState('');
   const [genre, setGenre] = useState('');
   const [length, setLength] = useState<number | ''>(''); // Supabase alanı
-  const [synopsis, setSynopsis] = useState(''); // Supabase alanı
+  const [synopsis, setSynopsis] = useState(''); // kısa özet
+  const [description, setDescription] = useState('');
+  const [priceCents, setPriceCents] = useState<number | ''>('');
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (id) fetchScript();
-  }, [id]);
+  const fetchScript = useCallback(async () => {
+    if (!id) return;
 
-  const fetchScript = async () => {
     const { data, error } = await supabase
       .from('scripts')
       .select('*')
@@ -30,11 +30,17 @@ export default function EditScriptPage() {
     } else if (data) {
       setTitle(data.title);
       setGenre(data.genre);
-      setLength(data.length);
-      setSynopsis(data.synopsis);
+      setLength(data.length ?? '');
+      setSynopsis(data.synopsis ?? '');
+      setDescription(data.description ?? '');
+      setPriceCents(data.price_cents ?? '');
     }
     setLoading(false);
-  };
+  }, [id]);
+
+  useEffect(() => {
+    fetchScript();
+  }, [fetchScript]);
 
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,6 +52,8 @@ export default function EditScriptPage() {
         genre,
         length: length === '' ? null : length,
         synopsis,
+        description,
+        price_cents: priceCents === '' ? null : priceCents,
       })
       .eq('id', id);
 
@@ -99,20 +107,53 @@ export default function EditScriptPage() {
             type="number"
             className="w-full p-2 border rounded-lg"
             value={length}
-            onChange={(e) => setLength(Number(e.target.value))}
+            onChange={(e) =>
+              setLength(e.target.value === '' ? '' : Number(e.target.value))
+            }
             required
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Açıklama</label>
+          <label className="block text-sm font-medium mb-1">
+            Kısa Özet (2-3 cümle)
+          </label>
           <textarea
             className="w-full p-2 border rounded-lg"
-            rows={5}
+            rows={3}
+            maxLength={350}
             value={synopsis}
             onChange={(e) => setSynopsis(e.target.value)}
             required
           ></textarea>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Detaylı Açıklama</label>
+          <textarea
+            className="w-full p-2 border rounded-lg"
+            rows={7}
+            minLength={50}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+          ></textarea>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Fiyat (₺)</label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            className="w-full p-2 border rounded-lg"
+            value={priceCents === '' ? '' : priceCents / 100}
+            onChange={(e) => {
+              const value = e.target.value;
+              setPriceCents(value === '' ? '' : Math.round(Number(value) * 100));
+            }}
+            required
+          />
         </div>
 
         <div className="flex gap-2">

--- a/app/dashboard/writer/scripts/new/page.tsx
+++ b/app/dashboard/writer/scripts/new/page.tsx
@@ -10,7 +10,9 @@ export default function NewScriptPage() {
   const [title, setTitle] = useState('');
   const [genre, setGenre] = useState('');
   const [length, setLength] = useState<number | ''>(''); // dakika
-  const [synopsis, setSynopsis] = useState(''); // açıklama
+  const [synopsis, setSynopsis] = useState(''); // kısa özet
+  const [description, setDescription] = useState('');
+  const [priceCents, setPriceCents] = useState<number | ''>('');
   const [userId, setUserId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -35,11 +37,13 @@ export default function NewScriptPage() {
 
     const { error } = await supabase.from('scripts').insert([
       {
+        owner_id: userId,
         title,
         genre,
         length: length === '' ? null : length,
         synopsis,
-        user_id: userId,
+        description,
+        price_cents: priceCents === '' ? null : priceCents,
       },
     ]);
 
@@ -51,6 +55,8 @@ export default function NewScriptPage() {
       setGenre('');
       setLength('');
       setSynopsis('');
+      setDescription('');
+      setPriceCents('');
       router.push('/dashboard/writer/scripts');
     }
   };
@@ -102,14 +108,49 @@ export default function NewScriptPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Açıklama</label>
+          <label className="block text-sm font-medium mb-1">
+            Kısa Özet (2-3 cümle)
+          </label>
           <textarea
             className="w-full p-2 border rounded-lg"
-            rows={5}
+            rows={3}
+            maxLength={350}
             value={synopsis}
             onChange={(e) => setSynopsis(e.target.value)}
             required
           ></textarea>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Detaylı Açıklama
+          </label>
+          <textarea
+            className="w-full p-2 border rounded-lg"
+            rows={7}
+            minLength={50}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+          ></textarea>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Fiyat (₺)
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            className="w-full p-2 border rounded-lg"
+            value={priceCents === '' ? '' : priceCents / 100}
+            onChange={(e) => {
+              const value = e.target.value;
+              setPriceCents(value === '' ? '' : Math.round(Number(value) * 100));
+            }}
+            required
+          />
         </div>
 
         <button

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary
- capture and persist new description and price_cents fields when creating or editing writer scripts
- clarify synopsis vs. description expectations through updated labels and length validation
- ensure the edit view refetches script data with the new metadata without hook dependency warnings

## Testing
- npx next lint --no-inline-config --max-warnings=0 --dir app/dashboard/writer/scripts/new --dir app/dashboard/writer/scripts/edit/[id]


------
https://chatgpt.com/codex/tasks/task_e_68c912b38b20832da730e4b41ba88657