### PR TITLE
Add pricing data to producer views and update owner filters

### DIFF
--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -11,6 +11,7 @@ type Script = {
   length: number | null; // dakika varsayımı
   synopsis: string | null;
   created_at: string;
+  price_cents: number | null;
 };
 
 export default function BrowseScriptsPage() {
@@ -29,7 +30,7 @@ export default function BrowseScriptsPage() {
     try {
       const { data, error } = await supabase
         .from('scripts')
-        .select('id, title, genre, length, synopsis, created_at')
+        .select('id, title, genre, length, synopsis, created_at, price_cents')
         .order('created_at', { ascending: false });
         
       if (error) throw error;
@@ -81,6 +82,15 @@ export default function BrowseScriptsPage() {
   const formatMinutes = (m: number | null) => {
     if (m == null) return '-';
     return `${m} dk`;
+  };
+
+  const formatPrice = (price: number | null) => {
+    if (price == null) return 'Belirtilmemiş';
+    return new Intl.NumberFormat('tr-TR', {
+      style: 'currency',
+      currency: 'TRY',
+      maximumFractionDigits: 2,
+    }).format(price / 100);
   };
 
   const excerpt = (text: string | null, max = 180) => {
@@ -168,7 +178,8 @@ export default function BrowseScriptsPage() {
             <div className="card space-y-2" key={s.id}>
               <h2 className="text-lg font-semibold">{s.title}</h2>
               <p className="text-sm text-[#7a5c36]">
-                Tür: {s.genre || '-'} &middot; Süre: {formatMinutes(s.length)}
+                Tür: {s.genre || '-'} · Süre: {formatMinutes(s.length)} · Fiyat:{' '}
+                {formatPrice(s.price_cents)}
               </p>
               <p className="text-sm text-[#4a3d2f]">{excerpt(s.synopsis)}</p>
               <div className="flex gap-2 mt-2">

--- a/app/dashboard/producer/scripts/[id]/page.tsx
+++ b/app/dashboard/producer/scripts/[id]/page.tsx
@@ -12,7 +12,9 @@ type Script = {
   length: string | number | null;
   synopsis: string | null;
   created_at: string;
-  user_id: string;
+  owner_id: string;
+  description: string | null;
+  price_cents: number | null;
   // Not: Şu an veri modelinizde dosya yolu alanı yok.
   // İleride storage kullanırsak ör. file_path veya pdf_url ekleyebiliriz.
 };
@@ -32,6 +34,15 @@ export default function ProducerScriptDetailPage() {
       month: '2-digit',
       day: '2-digit',
     }).format(new Date(iso));
+
+  const formatPrice = (price: number | null) => {
+    if (price == null) return 'Belirtilmemiş';
+    return new Intl.NumberFormat('tr-TR', {
+      style: 'currency',
+      currency: 'TRY',
+      maximumFractionDigits: 2,
+    }).format(price / 100);
+  };
 
   const fetchAll = useCallback(async (scriptId: string) => {
     try {
@@ -66,7 +77,9 @@ export default function ProducerScriptDetailPage() {
       // 3) Script detayını çek
       const { data: scData, error: scErr } = await supabase
         .from('scripts')
-        .select('id, title, genre, length, synopsis, created_at, user_id')
+        .select(
+          'id, title, genre, length, synopsis, description, price_cents, created_at, owner_id'
+        )
         .eq('id', scriptId)
         .single();
 
@@ -117,7 +130,8 @@ export default function ProducerScriptDetailPage() {
           <div>
             <h1 className="text-2xl font-bold">{script.title}</h1>
             <p className="text-sm text-gray-600">
-              Tür: {script.genre || '—'} · Süre: {script.length ?? '—'}
+              Tür: {script.genre || '—'} · Süre: {script.length ?? '—'} · Fiyat:{' '}
+              {formatPrice(script.price_cents)}
             </p>
             <p className="text-xs text-gray-400">
               Oluşturulma: {fmtDate(script.created_at)}
@@ -152,6 +166,13 @@ export default function ProducerScriptDetailPage() {
               <h2 className="text-lg font-semibold mb-2">Senaryonun Özeti</h2>
               <p className="text-[#4a3d2f] whitespace-pre-wrap">
                 {script.synopsis || 'Özet bulunamadı.'}
+              </p>
+            </div>
+
+            <div className="rounded-lg border p-4 bg-white/80">
+              <h2 className="text-lg font-semibold mb-2">Senaryonun Açıklaması</h2>
+              <p className="text-[#4a3d2f] whitespace-pre-wrap">
+                {script.description || 'Açıklama bulunamadı.'}
               </p>
             </div>
 

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -37,7 +37,7 @@ export default function WriterMessagesListPage() {
         producer:users ( id, email )
       `
       )
-      .eq('user_id', me.id)
+      .eq('owner_id', me.id)
       .eq('status', 'accepted')
       .order('created_at', { ascending: false });
 

--- a/app/dashboard/writer/notifications/page.tsx
+++ b/app/dashboard/writer/notifications/page.tsx
@@ -41,7 +41,7 @@ export default function WriterNotificationsPage() {
         producer:users ( id, email )
       `
       )
-      .eq('user_id', user.id)
+      .eq('owner_id', user.id)
       .in('status', ['accepted', 'rejected'])
       .order('created_at', { ascending: false });
 

--- a/app/dashboard/writer/requests/[id]/page.tsx
+++ b/app/dashboard/writer/requests/[id]/page.tsx
@@ -72,7 +72,7 @@ export default function WriterRequestDetailPage() {
     const { data, error } = await supabase
       .from('scripts')
       .select('id, title, genre, length')
-      .eq('user_id', user.id);
+      .eq('owner_id', user.id);
 
     if (!error && data) {
       setScripts(data as Script[]);
@@ -89,7 +89,7 @@ export default function WriterRequestDetailPage() {
       .from('applications')
       .select('id, status, script_id, created_at')
       .eq('request_id', requestId)
-      .eq('user_id', user.id)
+      .eq('owner_id', user.id)
       .maybeSingle();
 
     if (!error) setMyApplication((data as MyAppRow) || null);

--- a/app/dashboard/writer/requests/page.tsx
+++ b/app/dashboard/writer/requests/page.tsx
@@ -67,7 +67,7 @@ export default function WriterRequestsPage() {
     const { data: scrData } = await supabase
       .from('scripts')
       .select('*')
-      .eq('user_id', user.id);
+      .eq('owner_id', user.id);
 
     // Veriyi düzenle
     const formattedRequests = (reqData || []).map((req: any) => ({

--- a/app/dashboard/writer/scripts/page.tsx
+++ b/app/dashboard/writer/scripts/page.tsx
@@ -49,7 +49,7 @@ export default function MyScriptsPage() {
     const { data, error } = await supabase
       .from('scripts')
       .select('*')
-      .eq('user_id', user.id)
+      .eq('owner_id', user.id)
       .order('created_at', { ascending: false });
 
     if (error) {
@@ -84,7 +84,7 @@ export default function MyScriptsPage() {
       .from('scripts')
       .delete()
       .eq('id', id)
-      .eq('user_id', user.id);
+      .eq('owner_id', user.id);
 
     if (error) {
       alert('Silme başarısız: ' + error.message);

--- a/app/dashboard/writer/suggestions/page.tsx
+++ b/app/dashboard/writer/suggestions/page.tsx
@@ -53,7 +53,7 @@ export default function WriterSuggestionHistoryPage() {
         )
       `
       )
-      .eq('user_id', user.id)
+      .eq('owner_id', user.id)
       .order('created_at', { ascending: false });
 
     if (error) {

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -68,7 +68,7 @@ export default function UserMenu() {
             const { count } = await supabase
               .from('applications')
               .select('*', { count: 'exact', head: true })
-              .eq('user_id', user.id)
+              .eq('owner_id', user.id)
               .in('status', ['accepted', 'rejected']);
             setNotifCount(count ?? 0);
           }
@@ -78,7 +78,7 @@ export default function UserMenu() {
             const { count } = await supabase
               .from('applications')
               .select('*', { count: 'exact', head: true })
-              .eq('user_id', user.id)
+              .eq('owner_id', user.id)
               .eq('status', 'accepted');
             setChatCount(count ?? 0);
           }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary
- include script pricing data in producer browse and detail pages and display formatted values
- pull additional metadata such as description and owner_id when loading producer script details
- update writer dashboards to filter Supabase queries by owner_id instead of user_id

## Testing
- npm run lint *(fails: existing lint warnings across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c912b8b4f8832d97972b414b63c1ae