### PR TITLE
Expose script pricing in producer application views

### DIFF
--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -13,7 +13,8 @@ type ApplicationRow = {
   script_id: string;
   script_title: string;
   script_genre: string;
-  script_length: string | null;
+  length: number | null;
+  price_cents: number | null;
 };
 
 export default function ProducerApplicationsPage() {
@@ -43,7 +44,7 @@ export default function ProducerApplicationsPage() {
         request_id,
         script_id,
         requests!inner(id, title),
-        scripts!inner(id, title, genre, length)
+        scripts!inner(id, title, genre, length, price_cents)
       `)
       .eq('producer_id', user.id)
       .order('created_at', { ascending: false });
@@ -62,12 +63,34 @@ export default function ProducerApplicationsPage() {
         script_id: item.script_id,
         script_title: item.scripts?.title || '',
         script_genre: item.scripts?.genre || '',
-        script_length: item.scripts?.length?.toString() || null,
+        length:
+          typeof item.scripts?.length === 'number'
+            ? item.scripts.length
+            : item.scripts?.length != null
+            ? Number(item.scripts.length)
+            : null,
+        price_cents:
+          typeof item.scripts?.price_cents === 'number'
+            ? item.scripts.price_cents
+            : item.scripts?.price_cents != null
+            ? Number(item.scripts.price_cents)
+            : null,
       }));
       setApplications(formatted);
     }
 
     setLoading(false);
+  };
+
+  const formatPrice = (priceCents: number | null) => {
+    if (priceCents == null) {
+      return '—';
+    }
+
+    return (priceCents / 100).toLocaleString('tr-TR', {
+      style: 'currency',
+      currency: 'TRY',
+    });
   };
 
   const handleDecision = async (
@@ -135,7 +158,10 @@ export default function ProducerApplicationsPage() {
                     </h2>
                     <p className="text-sm text-[#7a5c36]">
                       Tür: {app.script_genre} · Süre:{' '}
-                      {app.script_length ? app.script_length : '—'}
+                      {app.length ?? '—'}
+                    </p>
+                    <p className="text-sm text-[#7a5c36]">
+                      Fiyat: {formatPrice(app.price_cents)}
                     </p>
                     <p className="text-sm text-[#7a5c36]">
                       İlan: {app.request_title}

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -3,7 +3,7 @@ export default function HowItWorksPage() {
     <div className="space-y-6">
       <h1 className="text-3xl font-bold">Nasıl Çalışır?</h1>
       <p>
-        PlotMatch'te senarist veya yapımcı olarak kayıt olabilirsiniz. Her
+        PlotMatch&apos;te senarist veya yapımcı olarak kayıt olabilirsiniz. Her
         kullanıcı tipi için özel bir panel sunuyoruz.
       </p>
       <ul className="list-disc pl-6">


### PR DESCRIPTION
## Summary
- request joined script pricing and numeric lengths when loading producer applications
- show script length and price details on producer application cards, including request detail view
- escape an apostrophe on the how-it-works page to satisfy eslint's no-unescaped-entities rule

## Testing
- npm run lint *(fails: existing react-hooks/exhaustive-deps and @next/next/no-img-element warnings elsewhere in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c912babf9c832d9102ca91035b72d7