### PR TITLE
Add producer listing creation and listing views

### DIFF
--- a/app/dashboard/producer/layout.tsx
+++ b/app/dashboard/producer/layout.tsx
@@ -38,6 +38,18 @@ export default function ProducerDashboardLayout({
             📓 Taleplerim
           </Link>
           <Link
+            href="/dashboard/producer/listings"
+            className="block hover:underline"
+          >
+            🎬 İlanlarım
+          </Link>
+          <Link
+            href="/dashboard/producer/listings/new"
+            className="block hover:underline"
+          >
+            ➕ Yeni İlan Oluştur
+          </Link>
+          <Link
             href="/dashboard/producer/applications"
             className="block hover:underline"
           >

--- a/app/dashboard/producer/listings/new/page.tsx
+++ b/app/dashboard/producer/listings/new/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import AuthGuard from '@/components/AuthGuard';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function NewProducerListingPage() {
+  const router = useRouter();
+  const [ownerId, setOwnerId] = useState<string | null>(null);
+  const [title, setTitle] = useState('');
+  const [genre, setGenre] = useState('');
+  const [description, setDescription] = useState('');
+  const [budget, setBudget] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        router.push('/auth/sign-in');
+        return;
+      }
+
+      setOwnerId(user.id);
+    };
+
+    fetchUser();
+  }, [router]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!ownerId) return;
+
+    setSubmitting(true);
+
+    const numericBudget = Number(budget);
+
+    if (!Number.isFinite(numericBudget)) {
+      alert('Lütfen geçerli bir bütçe değeri girin.');
+      setSubmitting(false);
+      return;
+    }
+
+    const budgetCents = Math.round(numericBudget * 100);
+
+    const { error } = await supabase.from('producer_listings').insert([
+      {
+        owner_id: ownerId,
+        title,
+        description,
+        genre,
+        budget_cents: budgetCents,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    if (error) {
+      alert('❌ İlan oluşturulamadı: ' + error.message);
+    } else {
+      alert('✅ İlan başarıyla oluşturuldu!');
+      router.push('/dashboard/producer/listings');
+    }
+
+    setSubmitting(false);
+  };
+
+  return (
+    <AuthGuard allowedRoles={['producer']}>
+      <div className="space-y-6 max-w-2xl">
+        <h1 className="text-2xl font-bold">🎬 Yeni Yapımcı İlanı</h1>
+        <p className="text-sm text-[#7a5c36]">
+          Projelerinizi duyurun ve yazarlarla iletişime geçin.
+        </p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium mb-1">Başlık</label>
+            <input
+              type="text"
+              className="w-full p-2 border rounded-lg"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Tür</label>
+            <select
+              className="w-full p-2 border rounded-lg"
+              value={genre}
+              onChange={(event) => setGenre(event.target.value)}
+              required
+            >
+              <option value="">Tür seçin</option>
+              <option value="dram">Dram</option>
+              <option value="gerilim">Gerilim</option>
+              <option value="komedi">Komedi</option>
+              <option value="bilim-kurgu">Bilim Kurgu</option>
+              <option value="belgesel">Belgesel</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Bütçe (₺)</label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              className="w-full p-2 border rounded-lg"
+              value={budget}
+              onChange={(event) => setBudget(event.target.value)}
+              required
+            />
+            <p className="text-xs text-[#a38d6d] mt-1">
+              Lütfen bütçeyi Türk Lirası cinsinden girin. Kuruş bilgisi opsiyoneldir.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Açıklama</label>
+            <textarea
+              className="w-full p-2 border rounded-lg"
+              rows={4}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="px-4 py-2 bg-[#0e5b4a] text-white rounded-lg hover:bg-[#0b4638] transition"
+            disabled={submitting || !ownerId}
+          >
+            {submitting ? 'Kaydediliyor...' : 'İlanı Yayınla'}
+          </button>
+        </form>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import AuthGuard from '@/components/AuthGuard';
+import { supabase } from '@/lib/supabaseClient';
+import type { ProducerListing } from '@/types/db';
+
+const currencyFormatter = new Intl.NumberFormat('tr-TR', {
+  style: 'currency',
+  currency: 'TRY',
+});
+
+const dateFormatter = new Intl.DateTimeFormat('tr-TR', {
+  dateStyle: 'medium',
+});
+
+export default function ProducerListingsPage() {
+  const router = useRouter();
+  const [listings, setListings] = useState<ProducerListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchListings = async () => {
+      setLoading(true);
+      setError(null);
+
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+
+      if (authError) {
+        setError(authError.message);
+        setLoading(false);
+        return;
+      }
+
+      if (!user) {
+        router.push('/auth/sign-in');
+        setLoading(false);
+        return;
+      }
+
+      const { data, error: listingsError } = await supabase
+        .from('producer_listings')
+        .select('*')
+        .eq('owner_id', user.id)
+        .order('created_at', { ascending: false });
+
+      if (listingsError) {
+        setError(listingsError.message);
+      } else {
+        setListings((data ?? []) as ProducerListing[]);
+      }
+
+      setLoading(false);
+    };
+
+    fetchListings();
+  }, [router]);
+
+  return (
+    <AuthGuard allowedRoles={['producer']}>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">🎬 İlanlarım</h1>
+            <p className="text-sm text-[#7a5c36]">
+              Yayınladığınız yapımcı ilanlarını buradan yönetebilirsiniz.
+            </p>
+          </div>
+          <Link
+            href="/dashboard/producer/listings/new"
+            className="inline-flex items-center px-4 py-2 bg-[#0e5b4a] text-white rounded-lg hover:bg-[#0b4638] transition"
+          >
+            ➕ Yeni İlan
+          </Link>
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-[#7a5c36]">İlanlar yükleniyor...</p>
+        ) : error ? (
+          <p className="text-sm text-red-600">❌ {error}</p>
+        ) : listings.length === 0 ? (
+          <div className="p-6 bg-white border border-dashed rounded-lg text-center space-y-2">
+            <p className="text-lg font-semibold">Henüz ilanınız yok.</p>
+            <p className="text-sm text-[#7a5c36]">
+              İlk ilanınızı oluşturarak yazarlarla bağlantı kurmaya başlayın.
+            </p>
+            <Link
+              href="/dashboard/producer/listings/new"
+              className="inline-flex items-center justify-center px-4 py-2 bg-[#ffaa06] text-white rounded-lg hover:bg-[#e69900] transition"
+            >
+              İlk ilanını oluştur
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {listings.map((listing) => (
+              <li
+                key={listing.id}
+                className="p-4 bg-white border rounded-lg shadow-sm space-y-2"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <h2 className="text-lg font-semibold text-[#0e5b4a]">
+                    {listing.title}
+                  </h2>
+                  <span className="text-sm font-medium text-[#ffaa06]">
+                    {currencyFormatter.format(listing.budget_cents / 100)}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-4 text-sm text-[#7a5c36]">
+                  <span>Tür: {listing.genre}</span>
+                  <span>
+                    Oluşturuldu: {dateFormatter.format(new Date(listing.created_at))}
+                  </span>
+                </div>
+                {listing.description && (
+                  <p className="text-sm text-[#4f3d2a]">{listing.description}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </AuthGuard>
+  );
+}

--- a/types/db.ts
+++ b/types/db.ts
@@ -23,6 +23,16 @@ export interface Script {
   created_at: string; // ISO
 }
 
+export interface ProducerListing {
+  id: string;
+  owner_id: string;
+  title: string;
+  description: string;
+  genre: string;
+  budget_cents: number;
+  created_at: string;
+}
+
 export interface Request {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- add a `ProducerListing` type to central Supabase type definitions
- add producer dashboard pages to create and list listings backed by Supabase auth
- expose navigation entries for managing producer listings

## Testing
- npm run lint *(fails: existing warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c91ae668b0832d89cd34b5779b33c3