### PR TITLE
Add orders table migration and types

### DIFF
--- a/supabase/migrations/20240611000000_create_orders.sql
+++ b/supabase/migrations/20240611000000_create_orders.sql
@@ -1,0 +1,7 @@
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  script_id uuid not null references public.scripts(id),
+  buyer_id uuid not null references public.users(id),
+  amount_cents integer not null,
+  created_at timestamp with time zone not null default now()
+);

--- a/types/db.ts
+++ b/types/db.ts
@@ -66,6 +66,14 @@ export interface Suggestion {
   created_at: string; // ISO
 }
 
+export interface Order {
+  id: string;
+  script_id: string;
+  buyer_id: string;
+  amount_cents: number;
+  created_at: string;
+}
+
 // Sayfalarda kullandığımız JOIN çıktı tipleri
 export interface ApplicationWithJoins {
   id: string;


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the `orders` table with keys to scripts and users
- expose an `Order` interface in the shared database types module

## Testing
- npm run lint *(fails: existing warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9218aa948832d8698e934dfa5fae0