### PR TITLE
Add purchase flow for scripts and fix lint issues

### DIFF
--- a/app/dashboard/producer/browse/[id]/page.tsx
+++ b/app/dashboard/producer/browse/[id]/page.tsx
@@ -1,20 +1,25 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 
 export default function ScriptDetailPage() {
-  const { id } = useParams();
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [script, setScript] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [hasPurchased, setHasPurchased] = useState(false);
+  const [purchaseMessage, setPurchaseMessage] = useState<string | null>(null);
+  const [purchaseError, setPurchaseError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchScript();
-  }, []);
+  const fetchScript = useCallback(async () => {
+    if (!id) {
+      setLoading(false);
+      return;
+    }
 
-  const fetchScript = async () => {
     const { data, error } = await supabase
       .from('scripts')
       .select('id, title, genre, length, price_cents, description')
@@ -27,6 +32,92 @@ export default function ScriptDetailPage() {
       setScript(data);
     }
     setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    fetchScript();
+  }, [fetchScript]);
+
+  const checkPurchaseStatus = useCallback(async () => {
+    if (!id) return;
+
+    try {
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+
+      if (authError) {
+        console.error('Satın alma durumu alınırken hata:', authError.message);
+        return;
+      }
+
+      if (!user) {
+        setHasPurchased(false);
+        return;
+      }
+
+      const { data: existingOrders, error: orderError } = await supabase
+        .from('orders')
+        .select('id')
+        .eq('script_id', id)
+        .eq('buyer_id', user.id)
+        .limit(1);
+
+      if (orderError) {
+        console.error('Satın alma durumu alınırken hata:', orderError.message);
+        return;
+      }
+
+      setHasPurchased(!!existingOrders && existingOrders.length > 0);
+    } catch (error) {
+      console.error('Satın alma durumu alınırken beklenmeyen hata:', error);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    checkPurchaseStatus();
+  }, [checkPurchaseStatus]);
+
+  const handlePurchase = async () => {
+    if (!id || !script) return;
+
+    setPurchaseError(null);
+    setPurchaseMessage(null);
+    setIsPurchasing(true);
+
+    try {
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+
+      if (authError) throw authError;
+
+      if (!user) {
+        setPurchaseError('Satın alma işlemi için giriş yapmalısınız.');
+        return;
+      }
+
+      const { error: insertError } = await supabase.from('orders').insert({
+        script_id: id,
+        buyer_id: user.id,
+        amount_cents: script.price_cents ?? 0,
+      });
+
+      if (insertError) throw insertError;
+
+      setHasPurchased(true);
+      setPurchaseMessage('Satın alma başarılı! Senaryo hesabınıza eklendi.');
+      await checkPurchaseStatus();
+    } catch (error: any) {
+      console.error('Satın alma işlemi sırasında hata:', error);
+      setPurchaseError(
+        error?.message || 'Satın alma işlemi sırasında bir sorun oluştu.'
+      );
+    } finally {
+      setIsPurchasing(false);
+    }
   };
 
   if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
@@ -45,10 +136,25 @@ export default function ScriptDetailPage() {
         <h2 className="text-lg font-semibold">Senaryo Açıklaması</h2>
         <p className="text-[#4a3d2f]">{script.description}</p>
 
-        <div className="pt-6">
-          <button className="btn btn-secondary" onClick={() => router.back()}>
-            Geri Dön
-          </button>
+        <div className="pt-6 space-y-3">
+          {purchaseMessage && (
+            <p className="text-sm text-green-600">{purchaseMessage}</p>
+          )}
+          {purchaseError && (
+            <p className="text-sm text-red-600">{purchaseError}</p>
+          )}
+          <div className="flex gap-3">
+            <button
+              className="btn btn-primary"
+              onClick={handlePurchase}
+              disabled={isPurchasing || hasPurchased}
+            >
+              {hasPurchased ? 'Satın Alındı' : 'Satın Al'}
+            </button>
+            <button className="btn btn-secondary" onClick={() => router.back()}>
+              Geri Dön
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/dashboard/producer/notifications/[id]/page.tsx
+++ b/app/dashboard/producer/notifications/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
 import { useParams } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
@@ -20,12 +20,11 @@ export default function ProducerNotificationDetailPage() {
   const [row, setRow] = useState<Row | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    load();
-  }, [id]);
-
-  const load = async () => {
-    if (!id) return;
+  const load = useCallback(async () => {
+    if (!id) {
+      setLoading(false);
+      return;
+    }
     const { data, error } = await supabase
       .from('applications')
       .select(
@@ -41,7 +40,11 @@ export default function ProducerNotificationDetailPage() {
 
     if (!error) setRow(data as Row);
     setLoading(false);
-  };
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/writer/notifications/[id]/page.tsx
+++ b/app/dashboard/writer/notifications/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
 import { useParams } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
@@ -20,12 +20,11 @@ export default function WriterNotificationDetailPage() {
   const [row, setRow] = useState<Row | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    load();
-  }, [id]);
-
-  const load = async () => {
-    if (!id) return;
+  const load = useCallback(async () => {
+    if (!id) {
+      setLoading(false);
+      return;
+    }
     const { data, error } = await supabase
       .from('applications')
       .select(
@@ -41,7 +40,11 @@ export default function WriterNotificationDetailPage() {
 
     if (!error) setRow(data as Row);
     setLoading(false);
-  };
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/writer/scripts/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 
@@ -17,17 +17,17 @@ type Script = {
 };
 
 export default function ScriptDetailPage() {
-  const { id } = useParams();
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
 
   const [script, setScript] = useState<Script | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (id) fetchScript();
-  }, [id]);
-
-  const fetchScript = async () => {
+  const fetchScript = useCallback(async () => {
+    if (!id) {
+      setLoading(false);
+      return;
+    }
     const { data, error } = await supabase
       .from('scripts')
       .select(
@@ -42,7 +42,11 @@ export default function ScriptDetailPage() {
       setScript(data);
     }
     setLoading(false);
-  };
+  }, [id]);
+
+  useEffect(() => {
+    fetchScript();
+  }, [fetchScript]);
 
   if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
   if (!script)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import TabTitleHandler from '../components/TabTitleHandler';
 import Link from 'next/link';
+import Image from 'next/image';
 import UserMenu from '@/components/UserMenu';
 
 export const metadata = {
@@ -22,10 +23,13 @@ export default function RootLayout({
           <div className="max-w-7xl mx-auto px-4 flex justify-between items-center">
             {/* Sol üstte logo */}
             <Link href="/" className="block h-12 w-auto overflow-visible">
-              <img
+              <Image
                 src="/ducktylo-logo.png"
                 alt="ducktylo logo"
-                className="h-16 -mt-2 object-contain"
+                width={128}
+                height={64}
+                className="h-16 -mt-2 w-auto object-contain"
+                priority
               />
             </Link>
 


### PR DESCRIPTION
## Summary
- add a Satın Al CTA to the producer script detail page and wire it to Supabase orders
- block repeat purchases by checking existing orders and surface success or error states
- refactor several detail pages to use stable callbacks and switch the layout logo to next/image to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9218be2bc832d8e76b80cdb75c3b4