### PR TITLE
Add producer purchases page and resolve lint warnings

### DIFF
--- a/app/dashboard/producer/browse/[id]/page.tsx
+++ b/app/dashboard/producer/browse/[id]/page.tsx
@@ -11,23 +11,28 @@ export default function ScriptDetailPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchScript();
-  }, []);
+    const load = async () => {
+      if (!id || typeof id !== 'string') {
+        setLoading(false);
+        return;
+      }
 
-  const fetchScript = async () => {
-    const { data, error } = await supabase
-      .from('scripts')
-      .select('id, title, genre, length, price_cents, description')
-      .eq('id', id)
-      .single();
+      const { data, error } = await supabase
+        .from('scripts')
+        .select('id, title, genre, length, price_cents, description')
+        .eq('id', id)
+        .single();
 
-    if (error) {
-      console.error('Hata:', error.message);
-    } else {
-      setScript(data);
-    }
-    setLoading(false);
-  };
+      if (error) {
+        console.error('Hata:', error.message);
+      } else {
+        setScript(data);
+      }
+      setLoading(false);
+    };
+
+    load();
+  }, [id]);
 
   if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
   if (!script)

--- a/app/dashboard/producer/layout.tsx
+++ b/app/dashboard/producer/layout.tsx
@@ -56,6 +56,12 @@ export default function ProducerDashboardLayout({
             📩 Başvurularım
           </Link>
           <Link
+            href="/dashboard/producer/purchases"
+            className="block hover:underline"
+          >
+            🧾 Satın Alımlarım
+          </Link>
+          <Link
             href="/dashboard/producer/billing"
             className="block hover:underline"
           >

--- a/app/dashboard/producer/notifications/[id]/page.tsx
+++ b/app/dashboard/producer/notifications/[id]/page.tsx
@@ -21,27 +21,30 @@ export default function ProducerNotificationDetailPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    load();
-  }, [id]);
-
-  const load = async () => {
-    if (!id) return;
-    const { data, error } = await supabase
-      .from('applications')
-      .select(
-        `
+    const load = async () => {
+      if (!id) {
+        setLoading(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('applications')
+        .select(
+          `
         id, created_at, status,
         script:scripts ( id, title ),
         request:requests ( id, title ),
         writer:users ( id, email )
       `
-      )
-      .eq('id', id)
-      .maybeSingle();
+        )
+        .eq('id', id)
+        .maybeSingle();
 
-    if (!error) setRow(data as Row);
-    setLoading(false);
-  };
+      if (!error) setRow(data as Row);
+      setLoading(false);
+    };
+
+    load();
+  }, [id]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/producer/purchases/page.tsx
+++ b/app/dashboard/producer/purchases/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import AuthGuard from '@/components/AuthGuard';
+import { supabase } from '@/lib/supabaseClient';
+
+type OrderRow = {
+  id: string;
+  created_at: string;
+  amount_cents: number | null;
+  script_title: string;
+  script_price_cents: number | null;
+};
+
+const formatPrice = (priceCents: number | null) => {
+  if (priceCents == null) {
+    return '—';
+  }
+
+  return (priceCents / 100).toLocaleString('tr-TR', {
+    style: 'currency',
+    currency: 'TRY',
+  });
+};
+
+const formatDateTime = (isoString: string) => {
+  try {
+    return new Date(isoString).toLocaleString('tr-TR');
+  } catch (error) {
+    return isoString;
+  }
+};
+
+export default function ProducerPurchasesPage() {
+  const [orders, setOrders] = useState<OrderRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  const fetchOrders = async () => {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('orders')
+      .select('id, amount_cents, created_at, scripts!inner(id,title,price_cents)')
+      .eq('producer_id', user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Satın alımlar alınamadı:', error.message);
+      setOrders([]);
+      setLoading(false);
+      return;
+    }
+
+    const formatted = (data || []).map((item: any) => ({
+      id: item.id,
+      created_at: item.created_at,
+      amount_cents:
+        typeof item.amount_cents === 'number'
+          ? item.amount_cents
+          : item.amount_cents != null
+          ? Number(item.amount_cents)
+          : null,
+      script_title: item.scripts?.title || 'Bilinmeyen Senaryo',
+      script_price_cents:
+        typeof item.scripts?.price_cents === 'number'
+          ? item.scripts.price_cents
+          : item.scripts?.price_cents != null
+          ? Number(item.scripts.price_cents)
+          : null,
+    }));
+
+    setOrders(formatted);
+    setLoading(false);
+  };
+
+  return (
+    <AuthGuard allowedRoles={['producer']}>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">🧾 Satın Aldığım Senaryolar</h1>
+        <p className="text-[#7a5c36]">
+          Satın aldığınız senaryoların geçmişini tarih ve ödeme tutarıyla birlikte
+          görüntüleyin.
+        </p>
+
+        {loading ? (
+          <p className="text-sm text-[#a38d6d]">Yükleniyor...</p>
+        ) : orders.length === 0 ? (
+          <div className="card">
+            <p className="text-sm text-[#a38d6d]">
+              Henüz herhangi bir senaryo satın almadınız.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {orders.map((order) => (
+              <div key={order.id} className="card space-y-2">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <h2 className="text-lg font-semibold text-[#0e5b4a]">
+                      {order.script_title}
+                    </h2>
+                    <p className="text-sm text-[#7a5c36]">
+                      Satın alma tarihi: {formatDateTime(order.created_at)}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-xs uppercase tracking-wide text-[#a38d6d]">
+                      Ödenen Tutar
+                    </p>
+                    <p className="text-lg font-bold text-[#0e5b4a]">
+                      {formatPrice(order.amount_cents ?? order.script_price_cents)}
+                    </p>
+                  </div>
+                </div>
+                {order.script_price_cents != null && (
+                  <p className="text-xs text-[#a38d6d]">
+                    Liste fiyatı: {formatPrice(order.script_price_cents)}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </AuthGuard>
+  );
+}

--- a/app/dashboard/writer/notifications/[id]/page.tsx
+++ b/app/dashboard/writer/notifications/[id]/page.tsx
@@ -21,27 +21,30 @@ export default function WriterNotificationDetailPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    load();
-  }, [id]);
-
-  const load = async () => {
-    if (!id) return;
-    const { data, error } = await supabase
-      .from('applications')
-      .select(
-        `
+    const load = async () => {
+      if (!id) {
+        setLoading(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('applications')
+        .select(
+          `
         id, created_at, status,
         script:scripts ( id, title ),
         request:requests ( id, title ),
         producer:users ( id, email )
       `
-      )
-      .eq('id', id)
-      .maybeSingle();
+        )
+        .eq('id', id)
+        .maybeSingle();
 
-    if (!error) setRow(data as Row);
-    setLoading(false);
-  };
+      if (!error) setRow(data as Row);
+      setLoading(false);
+    };
+
+    load();
+  }, [id]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/writer/scripts/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/[id]/page.tsx
@@ -24,25 +24,29 @@ export default function ScriptDetailPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (id) fetchScript();
+    const load = async () => {
+      if (!id || typeof id !== 'string') {
+        setLoading(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('scripts')
+        .select(
+          'id, title, genre, length, synopsis, description, price_cents, owner_id, created_at'
+        )
+        .eq('id', id)
+        .single();
+
+      if (error) {
+        console.error('❌ Veri alınamadı:', error.message);
+      } else {
+        setScript(data);
+      }
+      setLoading(false);
+    };
+
+    load();
   }, [id]);
-
-  const fetchScript = async () => {
-    const { data, error } = await supabase
-      .from('scripts')
-      .select(
-        'id, title, genre, length, synopsis, description, price_cents, owner_id, created_at'
-      )
-      .eq('id', id)
-      .single();
-
-    if (error) {
-      console.error('❌ Veri alınamadı:', error.message);
-    } else {
-      setScript(data);
-    }
-    setLoading(false);
-  };
 
   if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
   if (!script)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import TabTitleHandler from '../components/TabTitleHandler';
 import Link from 'next/link';
+import Image from 'next/image';
 import UserMenu from '@/components/UserMenu';
 
 export const metadata = {
@@ -22,10 +23,13 @@ export default function RootLayout({
           <div className="max-w-7xl mx-auto px-4 flex justify-between items-center">
             {/* Sol üstte logo */}
             <Link href="/" className="block h-12 w-auto overflow-visible">
-              <img
+              <Image
                 src="/ducktylo-logo.png"
                 alt="ducktylo logo"
-                className="h-16 -mt-2 object-contain"
+                width={128}
+                height={64}
+                priority
+                className="h-16 -mt-2 w-auto object-contain"
               />
             </Link>
 


### PR DESCRIPTION
## Summary
- add a producer purchases page that lists a producer's orders with amounts and timestamps
- surface the new purchases view from the producer sidebar
- resolve outstanding lint warnings by inlining async loaders and switching the logo to next/image

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9218c9678832d9e2fa90fa2c81368