### PR TITLE
Add applications table migration and update Application type

### DIFF
--- a/supabase/migrations/20240620000000_create_applications.sql
+++ b/supabase/migrations/20240620000000_create_applications.sql
@@ -1,0 +1,8 @@
+create table if not exists public.applications (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.producer_listings(id),
+  writer_id uuid not null references auth.users(id),
+  script_id uuid not null references public.scripts(id),
+  status text not null default 'pending',
+  created_at timestamptz not null default now()
+);

--- a/types/db.ts
+++ b/types/db.ts
@@ -49,12 +49,11 @@ export interface Request {
 
 export interface Application {
   id: string;
-  request_id: string;
+  listing_id: string;
+  writer_id: string;
   script_id: string;
-  user_id: string; // başvuruyu yapan (writer)
-  producer_id: string | null; // ilan sahibi (producer)
-  status: ApplicationStatus | string;
-  created_at: string; // ISO
+  status: ApplicationStatus;
+  created_at: string;
 }
 
 export interface Suggestion {


### PR DESCRIPTION
## Summary
- add a migration to create the applications table with required foreign keys and defaults
- update the Application interface in the shared types to reflect the new schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9278125c0832dbe1cb309583a3fcc