### PR TITLE
Add conversations/messages migration and types

### DIFF
--- a/supabase/migrations/20240621000000_create_conversations_messages.sql
+++ b/supabase/migrations/20240621000000_create_conversations_messages.sql
@@ -1,0 +1,14 @@
+create table public.conversations (
+  id uuid primary key default gen_random_uuid(),
+  application_id uuid not null references public.applications(id) unique,
+  created_at timestamptz default now()
+);
+
+create table public.messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.conversations(id),
+  sender_id uuid not null references auth.users(id),
+  body text not null,
+  created_at timestamptz default now()
+);
+

--- a/types/db.ts
+++ b/types/db.ts
@@ -73,6 +73,20 @@ export interface Order {
   created_at: string;
 }
 
+export interface Conversation {
+  id: string;
+  application_id: string;
+  created_at: string;
+}
+
+export interface Message {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  body: string;
+  created_at: string;
+}
+
 // Sayfalarda kullandığımız JOIN çıktı tipleri
 export interface ApplicationWithJoins {
   id: string;


### PR DESCRIPTION
## Summary
- add migration for conversations and messages tables
- expose TypeScript interfaces for the new tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c92d3581ac832d9fcde027b03f57f5