### PR TITLE
Ensure conversations are created when producers accept applications

### DIFF
--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -192,13 +192,29 @@ export default function ProducerListingDetailPage() {
     if (updateError) {
       console.error(updateError);
       alert('❌ Güncelleme hatası: ' + updateError.message);
-    } else {
-      setApplications((prev) =>
-        prev.map((app) =>
-          app.id === applicationId ? { ...app, status: decision } : app
-        )
-      );
+      setUpdatingId(null);
+      return;
     }
+
+    if (decision === 'accepted') {
+      const { error: upsertError } = await supabase
+        .from('conversations')
+        .upsert(
+          { application_id: applicationId },
+          { onConflict: 'application_id' }
+        );
+
+      if (upsertError) {
+        console.error(upsertError);
+        alert('❌ Sohbet başlatma hatası: ' + upsertError.message);
+      }
+    }
+
+    setApplications((prev) =>
+      prev.map((app) =>
+        app.id === applicationId ? { ...app, status: decision } : app
+      )
+    );
 
     setUpdatingId(null);
   };


### PR DESCRIPTION
## Summary
- update producer listing, request, and applications views to create or reuse a conversation when an application is accepted
- keep application status updates and user feedback in place while alerting if conversation setup fails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c92d3eb4b4832d8d19160ade8086b6