### PR TITLE
Update chat counts to use conversation joins

### DIFF
--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -56,16 +56,20 @@ export default function UserMenu() {
             setNotifCount(count ?? 0);
           }
 
-          // Sohbet: accepted başvurular (şimdilik = sohbetler)
+          // Sohbet: Bu yapımcının konuşmaları (conversations → applications → listings)
           {
             const { count } = await supabase
-              .from('applications')
-              .select('id, listing:producer_listings!inner(owner_id)', {
-                count: 'exact',
-                head: true,
-              })
-              .eq('listing.owner_id', user.id)
-              .eq('status', 'accepted');
+              .from('conversations')
+              .select(
+                `
+                  id,
+                  application:applications!inner(
+                    listing:producer_listings!inner(owner_id)
+                  )
+                `,
+                { count: 'exact', head: true }
+              )
+              .eq('application.listing.owner_id', user.id);
             setChatCount(count ?? 0);
           }
         } else if (role === 'writer') {
@@ -79,13 +83,18 @@ export default function UserMenu() {
             setNotifCount(count ?? 0);
           }
 
-          // Sohbet: accepted başvurular (şimdilik = sohbetler)
+          // Sohbet: Bu yazarın konuşmaları (conversations → applications)
           {
             const { count } = await supabase
-              .from('applications')
-              .select('*', { count: 'exact', head: true })
-              .eq('writer_id', user.id)
-              .eq('status', 'accepted');
+              .from('conversations')
+              .select(
+                `
+                  id,
+                  application:applications!inner(writer_id)
+                `,
+                { count: 'exact', head: true }
+              )
+              .eq('application.writer_id', user.id);
             setChatCount(count ?? 0);
           }
         } else {


### PR DESCRIPTION
## Summary
- update the producer chat counter to count conversations tied to listings owned by the user via applications
- update the writer chat counter to count conversations tied to the user's applications

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c92d4a3704832dab05213ef86775d4