### PR TITLE
Fix producer purchases filter to use buyer id

### DIFF
--- a/app/dashboard/producer/purchases/page.tsx
+++ b/app/dashboard/producer/purchases/page.tsx
@@ -6,6 +6,7 @@ import { supabase } from '@/lib/supabaseClient';
 
 type OrderRow = {
   id: string;
+  buyer_id: string;
   created_at: string;
   amount_cents: number | null;
   script_title: string;
@@ -51,8 +52,10 @@ export default function ProducerPurchasesPage() {
 
     const { data, error } = await supabase
       .from('orders')
-      .select('id, amount_cents, created_at, scripts!inner(id,title,price_cents)')
-      .eq('producer_id', user.id)
+      .select(
+        'id, buyer_id, amount_cents, created_at, scripts!inner(id,title,price_cents)'
+      )
+      .eq('buyer_id', user.id)
       .order('created_at', { ascending: false });
 
     if (error) {
@@ -64,6 +67,7 @@ export default function ProducerPurchasesPage() {
 
     const formatted = (data || []).map((item: any) => ({
       id: item.id,
+      buyer_id: item.buyer_id,
       created_at: item.created_at,
       amount_cents:
         typeof item.amount_cents === 'number'


### PR DESCRIPTION
## Summary
- filter producer purchases by `buyer_id` rather than `producer_id`
- include `buyer_id` in the order row type and data mapping

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c937774cd0832dbfa1a437ed541b54