### PR TITLE
feat: add ui kit and brand navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import './globals.css';
 import TabTitleHandler from '../components/TabTitleHandler';
 import Link from 'next/link';
-import Image from 'next/image';
 import UserMenu from '@/components/UserMenu';
 
 export const metadata = {
@@ -19,47 +18,23 @@ export default function RootLayout({
       <body className="min-h-screen bg-[#faf3e0] text-[#7a5c36] font-sans">
         <TabTitleHandler />
 
-        <header className="bg-[#0e5b4a] text-[#ffaa06] py-4 shadow-md">
-          <div className="max-w-7xl mx-auto px-4 flex justify-between items-center">
-            {/* Sol üstte logo */}
-            <Link href="/" className="block h-12 w-auto overflow-visible">
-              <Image
-                src="/ducktylo-logo.png"
-                alt="ducktylo logo"
-                width={128}
-                height={64}
-                priority
-                className="h-16 -mt-2 w-auto object-contain"
-              />
+        <header className="bg-forest text-brand py-4 shadow-md">
+          <div className="mx-auto flex max-w-7xl items-center justify-between px-4">
+            <Link href="/" className="text-2xl font-bold">
+              ducktylo
             </Link>
-
-            {/* Navigasyon + Sabit yerleşimli UserMenu */}
-            <div className="flex items-center space-x-4">
-              <nav className="flex items-center space-x-2 text-sm font-bold">
-                <Link href="/" className="hover:underline">
-                  Ana Sayfa
-                </Link>
-                <span className="text-white">|</span>
-                <Link href="/about" className="hover:underline">
-                  Hakkımızda
-                </Link>
-                <span className="text-white">|</span>
-                <Link href="/how-it-works" className="hover:underline">
-                  Nasıl Çalışır?
-                </Link>
-                <span className="text-white">|</span>
-                <Link href="/plans" className="hover:underline">
-                  Üyelik Planları
-                </Link>
-                <span className="text-white">|</span>
-                <Link href="/contact" className="hover:underline">
-                  İletişim
-                </Link>
-              </nav>
-
-              {/* Oturum alanı (sabit genişlik) */}
-              <UserMenu />
-            </div>
+            <nav className="flex items-center gap-4 text-sm font-semibold">
+              <Link href="/browse" className="hover:underline">
+                Browse
+              </Link>
+              <Link href="/dashboard" className="hover:underline">
+                Dashboard
+              </Link>
+              <Link href="/messages" className="hover:underline">
+                Messages
+              </Link>
+            </nav>
+            <UserMenu />
           </div>
         </header>
 

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Badge({
+  className = '',
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={`inline-block rounded-full bg-[#0e5b4a] px-2 py-1 text-xs font-semibold text-[#ffaa06] ${className}`}
+      {...props}
+    />
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export default function Button({
+  className = '',
+  variant = 'primary',
+  ...props
+}: ButtonProps) {
+  const base =
+    'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none';
+  const variants = {
+    primary:
+      'bg-[#ffaa06] text-[#0e5b4a] hover:bg-[#e6990a] focus:ring-[#0e5b4a]',
+    secondary:
+      'bg-[#0e5b4a] text-[#ffaa06] hover:bg-[#0b4a3b] focus:ring-[#ffaa06]',
+  } as const;
+  const variantClass = variants[variant] ?? variants.primary;
+  return (
+    <button className={`${base} ${variantClass} ${className}`} {...props} />
+  );
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Card({
+  className = '',
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`rounded-lg border border-[#0e5b4a] bg-white p-4 shadow-sm ${className}`}
+      {...props}
+    />
+  );
+}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface EmptyStateProps {
+  message: string;
+  children?: React.ReactNode;
+}
+
+export default function EmptyState({ message, children }: EmptyStateProps) {
+  return (
+    <div className="text-center text-[#0e5b4a]">
+      <p className="mb-4">{message}</p>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/ErrorState.tsx
+++ b/components/ui/ErrorState.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface ErrorStateProps {
+  message: string;
+  children?: React.ReactNode;
+}
+
+export default function ErrorState({ message, children }: ErrorStateProps) {
+  return (
+    <div className="rounded-md border border-[#ffaa06] bg-[#ffaa06]/20 p-4 text-center text-[#0e5b4a]">
+      <p className="mb-4 font-semibold">{message}</p>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/Spinner.tsx
+++ b/components/ui/Spinner.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Spinner({
+  className = '',
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`h-5 w-5 animate-spin rounded-full border-2 border-[#0e5b4a] border-t-transparent ${className}`}
+      {...props}
+    />
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,10 @@ const config = {
       fontFamily: {
         sans: ['"IBM Plex Mono"', 'Courier', 'monospace'],
       },
+      colors: {
+        brand: '#ffaa06',
+        forest: '#0e5b4a',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add basic UI kit components (button, card, badge, spinner, empty & error states)
- extend Tailwind theme with brand colors
- simplify header into brand navbar with Browse, Dashboard and Messages links

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c920c25f84832dbadad93007ef2408