### PR TITLE
fix(data): align queries with schema

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -38,7 +38,7 @@ export default function SignInPage() {
     // users.role oku
     const { data: profile } = await supabase
       .from('users')
-      .select('role')
+      .select('id, email, role')
       .eq('id', user.id)
       .maybeSingle();
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -21,7 +21,7 @@ export default function DashboardIndexRedirect() {
 
         const { data: row, error: rerr } = await supabase
           .from('users')
-          .select('role')
+          .select('id, email, role')
           .eq('id', user.id)
           .maybeSingle();
 

--- a/app/dashboard/producer/browse/[id]/page.tsx
+++ b/app/dashboard/producer/browse/[id]/page.tsx
@@ -31,7 +31,9 @@ export default function ScriptDetailPage() {
       try {
         const { data, error } = await supabase
           .from('scripts')
-          .select('id, title, genre, length, price_cents, description')
+          .select(
+            'id, title, genre, length, price_cents, description, created_at, owner_id'
+          )
           .eq('id', id)
           .single();
 
@@ -53,7 +55,7 @@ export default function ScriptDetailPage() {
         if (!userError && user) {
           const { data: existingOrder, error: orderError } = await supabase
             .from('orders')
-            .select('id')
+            .select('id, script_id, buyer_id, amount_cents, created_at')
             .eq('script_id', id)
             .eq('buyer_id', user.id)
             .maybeSingle();

--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -94,7 +94,7 @@ export default function ProducerListingDetailPage() {
             id,
             status,
             created_at,
-            script:scripts ( id, title, genre, length, price_cents ),
+            script:scripts ( id, title, genre, length, price_cents, created_at ),
             writer:users ( id, email )
           `;
 

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -46,7 +46,7 @@ export default function ProducerListingsPage() {
 
       const { data, error: listingsError } = await supabase
         .from('producer_listings')
-        .select('*')
+        .select('id, title, genre, description, budget_cents, created_at, owner_id')
         .eq('owner_id', user.id)
         .order('created_at', { ascending: false });
 

--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -140,12 +140,19 @@ export default function ProducerMessagesPage() {
               created_at,
               script:scripts!inner (
                 id,
-                title
+                title,
+                genre,
+                length,
+                price_cents,
+                created_at
               ),
               listing:producer_listings!inner (
                 id,
                 title,
-                owner_id
+                owner_id,
+                genre,
+                budget_cents,
+                created_at
               ),
               writer:users!inner (
                 id,
@@ -300,7 +307,7 @@ export default function ProducerMessagesPage() {
       try {
         const { data, error } = await supabase
           .from('messages')
-          .select('*')
+          .select('id, conversation_id, sender_id, body, created_at')
           .eq('conversation_id', selectedConversationId)
           .order('created_at', { ascending: true });
 

--- a/app/dashboard/producer/my-requests/page.tsx
+++ b/app/dashboard/producer/my-requests/page.tsx
@@ -37,7 +37,9 @@ export default function ProducerMyRequestsPage() {
 
     const { data, error } = await supabase
       .from('requests')
-      .select('*')
+      .select(
+        'id, title, description, genre, length, budget, deadline, created_at, producer_id'
+      )
       .eq('producer_id', user.id)
       .order('deadline', { ascending: false });
 

--- a/app/dashboard/producer/notifications/[id]/page.tsx
+++ b/app/dashboard/producer/notifications/[id]/page.tsx
@@ -29,11 +29,17 @@ export default function ProducerNotificationDetailPage() {
         .from('applications')
         .select(
           `
-        id, created_at, status,
-        script:scripts ( id, title ),
-        request:requests ( id, title ),
-        writer:users ( id, email )
-      `
+            id,
+            request_id,
+            listing_id,
+            writer_id,
+            script_id,
+            status,
+            created_at,
+            script:scripts ( id, title, genre, length, price_cents, created_at ),
+            request:requests ( id, title, genre, length, created_at ),
+            writer:users ( id, email )
+          `
         )
         .eq('id', id)
         .maybeSingle();

--- a/app/dashboard/producer/notifications/page.tsx
+++ b/app/dashboard/producer/notifications/page.tsx
@@ -33,13 +33,18 @@ export default function ProducerNotificationsPage() {
       .from('applications')
       .select(
         `
-        id,
-        created_at,
-        status,
-        script:scripts ( id, title ),
-        request:requests ( id, title ),
-        writer:users ( id, email )
-      `
+          id,
+          request_id,
+          listing_id,
+          writer_id,
+          producer_id,
+          script_id,
+          status,
+          created_at,
+          script:scripts ( id, title, genre, length, price_cents, created_at ),
+          request:requests ( id, title, genre, length, created_at ),
+          writer:users ( id, email )
+        `
       )
       .eq('producer_id', user.id)
       .eq('status', 'pending')

--- a/app/dashboard/producer/page.tsx
+++ b/app/dashboard/producer/page.tsx
@@ -83,12 +83,16 @@ export default function ProducerDashboardPage() {
         const [ordersResponse, listingsResponse] = await Promise.all([
           supabase
             .from('orders')
-            .select('id, amount_cents, created_at, scripts!inner(title)')
+            .select(
+              'id, script_id, buyer_id, amount_cents, created_at, scripts!inner(id, title, price_cents, created_at)'
+            )
             .eq('buyer_id', userId)
             .order('created_at', { ascending: false }),
           supabase
             .from('producer_listings')
-            .select('id, title, applications(status)')
+            .select(
+              'id, title, genre, budget_cents, created_at, applications(status)'
+            )
             .eq('owner_id', userId)
             .order('created_at', { ascending: false }),
         ]);

--- a/app/dashboard/producer/requests/[id]/page.tsx
+++ b/app/dashboard/producer/requests/[id]/page.tsx
@@ -50,7 +50,9 @@ export default function ProducerRequestDetailPage() {
   const fetchRequest = async (requestId: string) => {
     const { data, error } = await supabase
       .from('requests')
-      .select('*')
+      .select(
+        'id, title, description, genre, length, budget, created_at, user_id, producer_id'
+      )
       .eq('id', requestId)
       .single();
 
@@ -66,6 +68,9 @@ export default function ProducerRequestDetailPage() {
       .select(
         `
         id,
+        request_id,
+        listing_id,
+        writer_id,
         status,
         script:scripts ( id, title, genre, length, price_cents ),
         writer:users ( id, email )

--- a/app/dashboard/writer/listings/[id]/page.tsx
+++ b/app/dashboard/writer/listings/[id]/page.tsx
@@ -72,7 +72,7 @@ export default function ListingDetailPage() {
 
       const { data: scriptData, error: scriptError } = await supabase
         .from('scripts')
-        .select('id, title')
+        .select('id, title, genre, length, price_cents, created_at')
         .eq('owner_id', user.id);
 
       if (scriptError) {
@@ -92,7 +92,7 @@ export default function ListingDetailPage() {
 
       const { data: appData, error: appError } = await supabase
         .from('applications')
-        .select('id, script_id, status')
+        .select('id, listing_id, writer_id, script_id, status, created_at')
         .eq('listing_id', id)
         .eq('writer_id', user.id)
         .maybeSingle();
@@ -149,7 +149,7 @@ export default function ListingDetailPage() {
         script_id: selectedScript,
         status: 'pending',
       })
-      .select('id, script_id, status')
+      .select('id, listing_id, writer_id, script_id, status, created_at')
       .single();
 
     if (error) {

--- a/app/dashboard/writer/listings/page.tsx
+++ b/app/dashboard/writer/listings/page.tsx
@@ -25,7 +25,7 @@ export default function BrowseListingsPage() {
       setError(null);
       const { data, error } = await supabase
         .from('producer_listings')
-        .select('id, title, genre, description, budget_cents')
+        .select('id, title, genre, description, budget_cents, created_at')
         .order('created_at', { ascending: false });
       if (error) {
         setError(error.message);

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -102,11 +102,17 @@ export default function WriterMessagesPage() {
             id,
             script:scripts(
               id,
-              title
+              title,
+              genre,
+              length,
+              price_cents,
+              created_at
             ),
             listing:producer_listings!inner(
               id,
               title,
+              genre,
+              budget_cents,
               owner:users!producer_listings_owner_id_fkey(
                 id,
                 email
@@ -209,7 +215,7 @@ export default function WriterMessagesPage() {
 
       const { data, error } = await supabase
         .from('messages')
-        .select('*')
+        .select('id, conversation_id, sender_id, body, created_at')
         .eq('conversation_id', selectedConversationId)
         .order('created_at', { ascending: true });
 

--- a/app/dashboard/writer/notifications/[id]/page.tsx
+++ b/app/dashboard/writer/notifications/[id]/page.tsx
@@ -29,11 +29,16 @@ export default function WriterNotificationDetailPage() {
         .from('applications')
         .select(
           `
-        id, created_at, status,
-        script:scripts ( id, title ),
-        request:requests ( id, title ),
-        producer:users ( id, email )
-      `
+            id,
+            listing_id,
+            writer_id,
+            script_id,
+            status,
+            created_at,
+            script:scripts ( id, title, genre, length, price_cents, created_at ),
+            request:requests ( id, title, genre, length, created_at ),
+            producer:users ( id, email )
+          `
         )
         .eq('id', id)
         .maybeSingle();

--- a/app/dashboard/writer/notifications/page.tsx
+++ b/app/dashboard/writer/notifications/page.tsx
@@ -33,15 +33,18 @@ export default function WriterNotificationsPage() {
       .from('applications')
       .select(
         `
-        id,
-        created_at,
-        status,
-        script:scripts ( id, title ),
-        request:requests ( id, title ),
-        producer:users ( id, email )
-      `
+          id,
+          listing_id,
+          writer_id,
+          script_id,
+          status,
+          created_at,
+          script:scripts ( id, title, genre, length, price_cents, created_at ),
+          request:requests ( id, title, genre, length, created_at ),
+          producer:users ( id, email )
+        `
       )
-      .eq('owner_id', user.id)
+      .eq('writer_id', user.id)
       .in('status', ['accepted', 'rejected'])
       .order('created_at', { ascending: false });
 

--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -114,7 +114,9 @@ export default function WriterDashboardPage() {
 
         const { data: scriptData, error: scriptError } = await supabase
           .from('scripts')
-          .select('id,title,price_cents,orders(amount_cents)')
+          .select(
+            'id,title,genre,length,price_cents,created_at,orders(amount_cents)'
+          )
           .eq('owner_id', user.id)
           .order('created_at', { ascending: false });
 
@@ -145,10 +147,17 @@ export default function WriterDashboardPage() {
           .select(
             `
               id,
+              listing_id,
+              writer_id,
+              script_id,
               status,
+              created_at,
               listing:producer_listings (
                 id,
-                title
+                title,
+                genre,
+                budget_cents,
+                created_at
               )
             `
           )

--- a/app/dashboard/writer/requests/[id]/page.tsx
+++ b/app/dashboard/writer/requests/[id]/page.tsx
@@ -53,7 +53,9 @@ export default function WriterRequestDetailPage() {
   const fetchRequest = async (requestId: string) => {
     const { data, error } = await supabase
       .from('requests')
-      .select('*')
+      .select(
+        'id, title, description, genre, length, budget, created_at, user_id, producer_id'
+      )
       .eq('id', requestId)
       .single();
 
@@ -71,7 +73,7 @@ export default function WriterRequestDetailPage() {
 
     const { data, error } = await supabase
       .from('scripts')
-      .select('id, title, genre, length')
+      .select('id, title, genre, length, price_cents, created_at')
       .eq('owner_id', user.id);
 
     if (!error && data) {
@@ -87,9 +89,9 @@ export default function WriterRequestDetailPage() {
 
     const { data, error } = await supabase
       .from('applications')
-      .select('id, status, script_id, created_at')
+      .select('id, request_id, listing_id, writer_id, script_id, status, created_at')
       .eq('request_id', requestId)
-      .eq('owner_id', user.id)
+      .eq('writer_id', user.id)
       .maybeSingle();
 
     if (!error) setMyApplication((data as MyAppRow) || null);

--- a/app/dashboard/writer/requests/page.tsx
+++ b/app/dashboard/writer/requests/page.tsx
@@ -66,7 +66,7 @@ export default function WriterRequestsPage() {
     // Kullanıcının senaryolarını çek
     const { data: scrData } = await supabase
       .from('scripts')
-      .select('*')
+      .select('id, title, genre, length, price_cents, created_at, owner_id')
       .eq('owner_id', user.id);
 
     // Veriyi düzenle

--- a/app/dashboard/writer/scripts/edit/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/edit/[id]/page.tsx
@@ -15,18 +15,25 @@ export default function EditScriptPage() {
   const [description, setDescription] = useState('');
   const [priceCents, setPriceCents] = useState<number | ''>('');
   const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const fetchScript = useCallback(async () => {
     if (!id) return;
 
+    setErrorMessage(null);
     const { data, error } = await supabase
       .from('scripts')
-      .select('*')
+      .select(
+        'id, title, genre, length, synopsis, description, price_cents, owner_id, created_at'
+      )
       .eq('id', id)
       .single();
 
     if (error) {
       console.error('❌ Veri alınamadı:', error.message);
+      setErrorMessage(error.message ?? 'Senaryo bilgileri alınamadı.');
+    } else if (!data) {
+      setErrorMessage('Senaryo bulunamadı.');
     } else if (data) {
       setTitle(data.title);
       setGenre(data.genre);
@@ -65,6 +72,21 @@ export default function EditScriptPage() {
   };
 
   if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
+
+  if (errorMessage) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-red-600">{errorMessage}</p>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={() => router.push('/dashboard/writer/scripts')}
+        >
+          Senaryolara Dön
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6 max-w-2xl">

--- a/app/dashboard/writer/suggestions/page.tsx
+++ b/app/dashboard/writer/suggestions/page.tsx
@@ -38,22 +38,34 @@ export default function WriterSuggestionHistoryPage() {
       .from('applications')
       .select(
         `
-        id,
-        status,
-        created_at,
-        requests!inner (
           id,
-          title
-        ),
-        scripts!inner (
-          title
-        ),
-        producer:users!applications_producer_id_fkey (
-          email
-        )
-      `
+          request_id,
+          listing_id,
+          writer_id,
+          script_id,
+          status,
+          created_at,
+          requests!inner (
+            id,
+            title,
+            genre,
+            length,
+            created_at
+          ),
+          scripts!inner (
+            id,
+            title,
+            genre,
+            length,
+            price_cents,
+            created_at
+          ),
+          producer:users!applications_producer_id_fkey (
+            email
+          )
+        `
       )
-      .eq('owner_id', user.id)
+      .eq('writer_id', user.id)
       .order('created_at', { ascending: false });
 
     if (error) {

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -56,10 +56,26 @@ export default function UserMenu() {
           {
             const { count } = await supabase
               .from('applications')
-              .select('id, listing:producer_listings!inner(owner_id)', {
-                count: 'exact',
-                head: true,
-              })
+              .select(
+                `
+                  id,
+                  listing_id,
+                  writer_id,
+                  script_id,
+                  status,
+                  created_at,
+                  listing:producer_listings!inner (
+                    id,
+                    owner_id,
+                    title,
+                    created_at
+                  )
+                `,
+                {
+                  count: 'exact',
+                  head: true,
+                }
+              )
               .eq('listing.owner_id', user.id)
               .eq('status', 'pending');
             setNotifCount(count ?? 0);
@@ -72,8 +88,21 @@ export default function UserMenu() {
               .select(
                 `
                   id,
-                  application:applications!inner(
-                    listing:producer_listings!inner(owner_id)
+                  application_id,
+                  created_at,
+                  application:applications!inner (
+                    id,
+                    listing_id,
+                    writer_id,
+                    script_id,
+                    status,
+                    created_at,
+                    listing:producer_listings!inner (
+                      id,
+                      owner_id,
+                      title,
+                      created_at
+                    )
                   )
                 `,
                 { count: 'exact', head: true }
@@ -86,7 +115,10 @@ export default function UserMenu() {
           {
             const { count } = await supabase
               .from('applications')
-              .select('*', { count: 'exact', head: true })
+              .select(
+                'id, listing_id, writer_id, script_id, status, created_at',
+                { count: 'exact', head: true }
+              )
               .eq('writer_id', user.id)
               .in('status', ['accepted', 'rejected']);
             setNotifCount(count ?? 0);
@@ -99,7 +131,16 @@ export default function UserMenu() {
               .select(
                 `
                   id,
-                  application:applications!inner(writer_id)
+                  application_id,
+                  created_at,
+                  application:applications!inner (
+                    id,
+                    listing_id,
+                    writer_id,
+                    script_id,
+                    status,
+                    created_at
+                  )
                 `,
                 { count: 'exact', head: true }
               )


### PR DESCRIPTION
## Summary
- standardize Supabase selects to fetch canonical script, listing, and application columns across dashboard and menu views
- align request/application filters with schema naming and ensure price/length fields use canonical names
- add an error fallback for the writer script edit page when Supabase data is unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c95940eef8832da7bb5f4f9193a429