### PR TITLE
Add SQL migrations to set script defaults and backfill data

### DIFF
--- a/sql/migrations/mvp_backfill.sql
+++ b/sql/migrations/mvp_backfill.sql
@@ -1,0 +1,5 @@
+update scripts
+set owner_id = coalesce(owner_id, user_id);
+
+update scripts
+set price_cents = coalesce(price_cents, 0);

--- a/sql/migrations/mvp_patch.sql
+++ b/sql/migrations/mvp_patch.sql
@@ -1,0 +1,8 @@
+alter table scripts
+  alter column owner_id set default auth.uid();
+
+alter table scripts
+  alter column price_cents set default 0;
+
+create index if not exists scripts_owner_created_idx
+  on scripts(owner_id, created_at);


### PR DESCRIPTION
## Summary
- add a patch migration to set default values for script ownership and pricing and ensure indexing
- add a backfill migration to populate missing owner_id and price_cents values

## Testing
- not run (database access unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68c970fd5624832da2a60cb53bd8e1c4