### PR TITLE
Use writer_id for request applications

### DIFF
--- a/app/dashboard/writer/requests/page.tsx
+++ b/app/dashboard/writer/requests/page.tsx
@@ -104,7 +104,7 @@ export default function WriterRequestsPage() {
       {
         request_id: selectedRequest.id,
         script_id: selectedScriptId,
-        user_id: userId,
+        writer_id: userId,
         producer_id: reqDetails.producer_id,
         status: 'pending',
       },

--- a/supabase/migrations/20240716000000_backfill_applications_writer_id.sql
+++ b/supabase/migrations/20240716000000_backfill_applications_writer_id.sql
@@ -1,0 +1,3 @@
+-- Ensure existing application rows have writer_id populated
+update public.applications
+set writer_id = coalesce(writer_id, user_id);

--- a/types/db.ts
+++ b/types/db.ts
@@ -49,11 +49,16 @@ export interface Request {
 
 export interface Application {
   id: string;
-  listing_id: string;
+  request_id?: string | null;
+  listing_id?: string | null;
+  producer_listing_id?: string | null;
   writer_id: string;
   script_id: string;
+  producer_id?: string | null;
+  owner_id?: string | null;
   status: ApplicationStatus;
   created_at: string;
+  updated_at?: string;
 }
 
 export interface Suggestion {


### PR DESCRIPTION
## Summary
- send writer applications using the `writer_id` column instead of the legacy `user_id`
- extend the shared `Application` type to expose `writer_id` and related optional fields
- add a SQL migration to backfill `writer_id` values from historical records

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c970fc6fb4832d83dbe6c78a8f8bac