### PR TITLE
Use writer_id for applications

### DIFF
--- a/app/dashboard/writer/requests/[id]/page.tsx
+++ b/app/dashboard/writer/requests/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function WriterRequestDetailPage() {
       {
         request_id: request.id,
         script_id: selectedScript,
-        user_id: user.id, // writer
+        writer_id: user.id,
         producer_id: (request as any).producer_id ?? request.user_id,
 
         status: 'pending',

--- a/app/dashboard/writer/requests/page.tsx
+++ b/app/dashboard/writer/requests/page.tsx
@@ -30,7 +30,7 @@ export default function WriterRequestsPage() {
   const [loading, setLoading] = useState(true);
   const [selectedRequest, setSelectedRequest] = useState<Request | null>(null);
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
-  const [userId, setUserId] = useState<string | null>(null);
+  const [writerId, setWriterId] = useState<string | null>(null);
 
   const router = useRouter();
 
@@ -44,7 +44,7 @@ export default function WriterRequestsPage() {
     } = await supabase.auth.getUser();
     if (!user) return;
 
-    setUserId(user.id);
+    setWriterId(user.id);
 
     // Talepleri çek
     const { data: reqData } = await supabase
@@ -86,7 +86,7 @@ export default function WriterRequestsPage() {
   };
 
   const handleApply = async () => {
-    if (!selectedRequest || !selectedScriptId || !userId) return;
+    if (!selectedRequest || !selectedScriptId || !writerId) return;
 
     // İlan sahibinin (producer) id'sini çek
     const { data: reqDetails } = await supabase
@@ -104,7 +104,7 @@ export default function WriterRequestsPage() {
       {
         request_id: selectedRequest.id,
         script_id: selectedScriptId,
-        user_id: userId,
+        writer_id: writerId,
         producer_id: reqDetails.producer_id,
         status: 'pending',
       },

--- a/sql/migrations/mvp_backfill.sql
+++ b/sql/migrations/mvp_backfill.sql
@@ -1,0 +1,1 @@
+update applications set writer_id = coalesce(writer_id, user_id);

--- a/sql/migrations/mvp_patch.sql
+++ b/sql/migrations/mvp_patch.sql
@@ -1,0 +1,1 @@
+create index if not exists applications_writer_idx on applications(writer_id);


### PR DESCRIPTION
## Summary
- backfill existing application rows so writer_id defaults to user_id
- add an index on applications.writer_id for the MVP patch rollout
- update writer request apply flows to insert applications with writer_id only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c971152a80832dad774c834032f950