### PR TITLE
feat: add unified listings view and update queries

### DIFF
--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -43,10 +43,10 @@ export default function ProducerApplicationsPage() {
         created_at,
         listing_id,
         script_id,
-        producer_listings!inner(id, title, owner_id),
+        listing:v_listings_unified!inner(id, title, owner_id, source),
         scripts!inner(id, title, genre, length, price_cents)
       `)
-      .eq('producer_listings.owner_id', user.id)
+      .eq('owner_id', user.id)
       .order('created_at', { ascending: false });
 
     if (error) {
@@ -55,9 +55,9 @@ export default function ProducerApplicationsPage() {
     } else {
       // Veriyi düzenle
       const formatted = (data || []).map((item: any) => {
-        const listing = Array.isArray(item.producer_listings)
-          ? item.producer_listings[0]
-          : item.producer_listings;
+        const listing = Array.isArray(item.listing)
+          ? item.listing[0]
+          : item.listing;
         const script = Array.isArray(item.scripts)
           ? item.scripts[0]
           : item.scripts;

--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -146,13 +146,14 @@ export default function ProducerMessagesPage() {
                 price_cents,
                 created_at
               ),
-              listing:producer_listings!inner (
+              listing:v_listings_unified!inner (
                 id,
                 title,
                 owner_id,
                 genre,
                 budget_cents,
-                created_at
+                created_at,
+                source
               ),
               writer:users!inner (
                 id,
@@ -161,7 +162,7 @@ export default function ProducerMessagesPage() {
             )
           `
         )
-        .eq('application.listing.owner_id', user.id)
+        .eq('application.owner_id', user.id)
         .order('created_at', { ascending: false });
 
       if (error) {

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -14,8 +14,12 @@ type ConversationRow = {
     listing?: {
       id: string;
       title: string | null;
-      owner?: { id: string; email: string | null }[] | null;
+      genre?: string | null;
+      budget_cents?: number | null;
+      owner_id?: string | null;
+      source?: string | null;
     }[] | null;
+    owner?: { id: string; email: string | null }[] | null;
   } | null;
 };
 
@@ -108,15 +112,18 @@ export default function WriterMessagesPage() {
               price_cents,
               created_at
             ),
-            listing:producer_listings!inner(
+            listing:v_listings_unified!inner(
               id,
               title,
               genre,
               budget_cents,
-              owner:users!producer_listings_owner_id_fkey(
-                id,
-                email
-              )
+              owner_id,
+              source,
+              created_at
+            ),
+            owner:users!applications_owner_id_fkey(
+              id,
+              email
             ),
             writer_id
           )
@@ -143,7 +150,7 @@ export default function WriterMessagesPage() {
         const script = Array.isArray(scriptData) ? scriptData[0] : scriptData;
         const listingData = application?.listing;
         const listing = Array.isArray(listingData) ? listingData[0] : listingData;
-        const ownerData = listing?.owner;
+        const ownerData = application?.owner;
         const owner = Array.isArray(ownerData) ? ownerData[0] : ownerData;
 
         return {

--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -24,7 +24,7 @@ type ScriptStat = {
   revenueCents: number;
 };
 
-type ProducerListingRow = {
+type ListingRow = {
   id: string;
   title: string;
 };
@@ -32,7 +32,7 @@ type ProducerListingRow = {
 type ApplicationQueryRow = {
   id: string;
   status: string | null;
-  listing?: ProducerListingRow | ProducerListingRow[] | null;
+  listing?: ListingRow | ListingRow[] | null;
 };
 
 type ApplicationSummary = {
@@ -152,12 +152,13 @@ export default function WriterDashboardPage() {
               script_id,
               status,
               created_at,
-              listing:producer_listings (
+              listing:v_listings_unified!inner (
                 id,
                 title,
                 genre,
                 budget_cents,
-                created_at
+                created_at,
+                source
               )
             `
           )

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -64,11 +64,11 @@ export default function UserMenu() {
                   script_id,
                   status,
                   created_at,
-                  listing:producer_listings!inner (
+                  listing:v_listings_unified!inner (
                     id,
                     owner_id,
                     title,
-                    created_at
+                    source
                   )
                 `,
                 {
@@ -76,7 +76,7 @@ export default function UserMenu() {
                   head: true,
                 }
               )
-              .eq('listing.owner_id', user.id)
+              .eq('owner_id', user.id)
               .eq('status', 'pending');
             setNotifCount(count ?? 0);
           }
@@ -97,17 +97,17 @@ export default function UserMenu() {
                     script_id,
                     status,
                     created_at,
-                    listing:producer_listings!inner (
+                    listing:v_listings_unified!inner (
                       id,
                       owner_id,
                       title,
-                      created_at
+                      source
                     )
                   )
                 `,
                 { count: 'exact', head: true }
               )
-              .eq('application.listing.owner_id', user.id);
+              .eq('application.owner_id', user.id);
             setChatCount(count ?? 0);
           }
         } else if (role === 'writer') {

--- a/supabase/migrations/20240715000000_create_v_listings_unified.sql
+++ b/supabase/migrations/20240715000000_create_v_listings_unified.sql
@@ -1,0 +1,26 @@
+-- Create a unified view to present listings from both producer_listings and requests
+create or replace view public.v_listings_unified as
+select
+  l.id,
+  l.owner_id,
+  l.title,
+  l.description,
+  l.genre,
+  l.budget_cents,
+  l.created_at,
+  'producer_listings'::text as source
+from public.producer_listings l
+union all
+select
+  r.id,
+  coalesce(r.producer_id, r.user_id) as owner_id,
+  r.title,
+  r.description,
+  r.genre,
+  case
+    when r.budget is null then null
+    else round(r.budget)::integer
+  end as budget_cents,
+  r.created_at,
+  'requests'::text as source
+from public.requests r;

--- a/types/db.ts
+++ b/types/db.ts
@@ -23,6 +23,19 @@ export interface Script {
   created_at: string; // ISO
 }
 
+export type ListingSource = 'producer_listings' | 'requests';
+
+export interface Listing {
+  id: string;
+  owner_id: string | null;
+  title: string;
+  description: string | null;
+  genre: string;
+  budget_cents: number | null;
+  created_at: string;
+  source: ListingSource;
+}
+
 export interface ProducerListing {
   id: string;
   owner_id: string;


### PR DESCRIPTION
## Summary
- create the `v_listings_unified` view to surface producer listings and requests through a shared shape
- add a `Listing` TypeScript type for the unified view
- refactor messaging and dashboard Supabase queries to pull listings from the unified view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c97117457c832d9f488d89896a24f5