### PR TITLE
feat: add session-aware app header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import TabTitleHandler from '../components/TabTitleHandler';
-import Link from 'next/link';
-import UserMenu from '@/components/UserMenu';
+
+import AppHeader from '@/components/AppHeader';
 
 export const metadata = {
   title: 'ducktylo | Senaristler ve Yapımcılar için ortak nokta!',
@@ -18,25 +18,7 @@ export default function RootLayout({
       <body className="min-h-screen bg-[#faf3e0] text-[#7a5c36] font-sans">
         <TabTitleHandler />
 
-        <header className="bg-forest text-brand py-4 shadow-md">
-          <div className="mx-auto flex max-w-7xl items-center justify-between px-4">
-            <Link href="/" className="text-2xl font-bold">
-              ducktylo
-            </Link>
-            <nav className="flex items-center gap-4 text-sm font-semibold">
-              <Link href="/browse" className="hover:underline">
-                Browse
-              </Link>
-              <Link href="/dashboard" className="hover:underline">
-                Dashboard
-              </Link>
-              <Link href="/messages" className="hover:underline">
-                Messages
-              </Link>
-            </nav>
-            <UserMenu />
-          </div>
-        </header>
+        <AppHeader />
 
         <main className="max-w-7xl mx-auto px-4 py-10">{children}</main>
 

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+import UserMenu from '@/components/UserMenu';
+import { useSession } from '@/hooks/useSession';
+
+const publicLinks = [
+  { href: '/', label: 'Home' },
+  { href: '/about', label: 'About' },
+  { href: '/how-it-works', label: 'How It Works' },
+  { href: '/plans', label: 'Plans' },
+];
+
+const appLinks = [
+  { href: '/browse', label: 'Browse' },
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/messages', label: 'Messages' },
+];
+
+export default function AppHeader() {
+  const { session } = useSession();
+  const navigation = session ? appLinks : publicLinks;
+
+  return (
+    <header className="bg-forest text-brand py-4 shadow-md">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4">
+        <Link href="/" className="flex items-center gap-2">
+          <Image
+            src="/ducktylo-logo.png"
+            alt="ducktylo logo"
+            width={120}
+            height={32}
+            className="h-8 w-auto"
+            priority
+          />
+          <span className="sr-only">ducktylo</span>
+        </Link>
+        <nav className="flex items-center gap-4 text-sm font-semibold">
+          {navigation.map((link) => (
+            <Link key={link.href} href={link.href} className="hover:underline">
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <UserMenu />
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a client AppHeader component that renders the logo and adapts navigation based on session state
- replace the inline header in the root layout with the reusable AppHeader while preserving styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8e18f998832db210f256785979d6