### PR TITLE
feat: centralize plan data and reuse across billing pages

### DIFF
--- a/app/dashboard/producer/billing/page.tsx
+++ b/app/dashboard/producer/billing/page.tsx
@@ -1,37 +1,81 @@
+'use client';
+
+import Link from 'next/link';
 import AuthGuard from '@/components/AuthGuard';
+import { usePlanData } from '@/hooks/usePlanData';
+import { getPlanById } from '@/lib/plans';
+
 export default function ProducerBillingPage() {
   return (
     <AuthGuard allowedRoles={['producer']}>
-      <div className="space-y-6">
-        <h1 className="text-2xl font-bold">💳 Üyelik ve Fatura Bilgileri</h1>
-        <p className="text-[#7a5c36]">
-          Mevcut planınız ve geçmiş ödemeleriniz burada listelenir.
-        </p>
+      <BillingContent />
+    </AuthGuard>
+  );
+}
 
-        {/* Aktif Plan */}
-        <div className="card space-y-2">
-          <h2 className="text-lg font-semibold">
-            🔐 Aktif Plan: <span className="text-[#ffaa06]">Basic</span>
-          </h2>
+function BillingContent() {
+  const { selection, loading } = usePlanData();
+  const plan = selection ? getPlanById(selection.planId) : undefined;
+
+  if (loading) {
+    return <p className="text-center text-[#7a5c36]">Plan bilgilerin yükleniyor...</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">💳 Üyelik ve Fatura Bilgileri</h1>
+      <p className="text-[#7a5c36]">
+        Mevcut planınız ve geçmiş ödemeleriniz burada listelenir.
+      </p>
+
+      <div className="card space-y-2">
+        <h2 className="text-lg font-semibold">
+          🔐 Aktif Plan:{' '}
+          <span className="text-[#ffaa06]">
+            {plan ? `${plan.icon} ${plan.name}` : 'Plan seçimi bulunamadı'}
+          </span>
+        </h2>
+        {selection?.renewsAt ? (
+          <p className="text-sm text-[#7a5c36]">Yenileme Tarihi: {selection.renewsAt}</p>
+        ) : (
           <p className="text-sm text-[#7a5c36]">
-            Yenileme Tarihi: 01 Ağustos 2025
+            Plan yenileme bilgisi bulunamadı. Seçenekleri{' '}
+            <Link href="/plans" className="text-[#ffaa06] underline">
+              Planlar sayfasından
+            </Link>{' '}
+            inceleyebilirsiniz.
           </p>
-          <div className="flex gap-3 mt-2">
-            <button className="btn btn-secondary">Planı Yükselt</button>
-            <button className="btn btn-danger">İptal Et</button>
-          </div>
-        </div>
-
-        {/* Fatura Geçmişi */}
-        <div className="card space-y-2">
-          <h2 className="text-lg font-semibold">📄 Fatura Geçmişi</h2>
-          <ul className="text-sm text-[#7a5c36] list-disc list-inside">
-            <li>01 Temmuz 2025 — ₺149 — Basic Plan</li>
-            <li>01 Haziran 2025 — ₺149 — Basic Plan</li>
-            <li>01 Mayıs 2025 — ₺149 — Basic Plan</li>
-          </ul>
+        )}
+        <div className="flex gap-3 mt-2">
+          <button className="btn btn-secondary">Planı Yükselt</button>
+          <button className="btn btn-danger">İptal Et</button>
         </div>
       </div>
-    </AuthGuard>
+
+      <div className="card space-y-2">
+        <h2 className="text-lg font-semibold">📄 Fatura Geçmişi</h2>
+        {selection?.history?.length ? (
+          <ul className="text-sm text-[#7a5c36] list-disc list-inside space-y-1">
+            {selection.history.map((entry) => {
+              const historyPlan = getPlanById(entry.planId);
+              return (
+                <li key={entry.id}>
+                  {entry.billedAt} — {entry.amount} — {historyPlan ? historyPlan.name : 'Plan'}
+                  {' '}({entry.status})
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="text-sm text-[#7a5c36]">
+            Henüz fatura geçmişiniz bulunmuyor. Daha fazla bilgi için{' '}
+            <Link href="/plans" className="text-[#ffaa06] underline">
+              Planlar sayfasını
+            </Link>{' '}
+            ziyaret edebilirsiniz.
+          </p>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/dashboard/writer/billing/page.tsx
+++ b/app/dashboard/writer/billing/page.tsx
@@ -1,37 +1,81 @@
+'use client';
+
+import Link from 'next/link';
 import AuthGuard from '@/components/AuthGuard';
+import { usePlanData } from '@/hooks/usePlanData';
+import { getPlanById } from '@/lib/plans';
+
 export default function WriterBillingPage() {
   return (
     <AuthGuard allowedRoles={['writer']}>
-      <div className="space-y-6">
-        <h1 className="text-2xl font-bold">💳 Üyelik ve Fatura Bilgileri</h1>
-        <p className="text-[#7a5c36]">
-          Aktif planını ve ödeme geçmişini buradan takip edebilirsin.
-        </p>
+      <BillingContent />
+    </AuthGuard>
+  );
+}
 
-        {/* Aktif Plan */}
-        <div className="card space-y-2">
-          <h2 className="text-lg font-semibold">
-            🔐 Aktif Plan: <span className="text-[#ffaa06]">Pro</span>
-          </h2>
+function BillingContent() {
+  const { selection, loading } = usePlanData();
+  const plan = selection ? getPlanById(selection.planId) : undefined;
+
+  if (loading) {
+    return <p className="text-center text-[#7a5c36]">Plan bilgilerin yükleniyor...</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">💳 Üyelik ve Fatura Bilgileri</h1>
+      <p className="text-[#7a5c36]">
+        Aktif planını ve ödeme geçmişini buradan takip edebilirsin.
+      </p>
+
+      <div className="card space-y-2">
+        <h2 className="text-lg font-semibold">
+          🔐 Aktif Plan:{' '}
+          <span className="text-[#ffaa06]">
+            {plan ? `${plan.icon} ${plan.name}` : 'Plan seçimi bulunamadı'}
+          </span>
+        </h2>
+        {selection?.renewsAt ? (
+          <p className="text-sm text-[#7a5c36]">Yenileme Tarihi: {selection.renewsAt}</p>
+        ) : (
           <p className="text-sm text-[#7a5c36]">
-            Yenileme Tarihi: 31 Ağustos 2025
+            Plan yenileme bilgisi bulunamadı. Planlarını{' '}
+            <Link href="/plans" className="text-[#ffaa06] underline">
+              Planlar sayfasından
+            </Link>{' '}
+            güncelleyebilirsin.
           </p>
-          <div className="flex gap-3 mt-2">
-            <button className="btn btn-secondary">Planı Yükselt</button>
-            <button className="btn btn-danger">İptal Et</button>
-          </div>
-        </div>
-
-        {/* Fatura Geçmişi */}
-        <div className="card space-y-2">
-          <h2 className="text-lg font-semibold">📄 Fatura Geçmişi</h2>
-          <ul className="text-sm text-[#7a5c36] list-disc list-inside">
-            <li>01 Temmuz 2025 — ₺299 — Pro Plan</li>
-            <li>01 Haziran 2025 — ₺299 — Pro Plan</li>
-            <li>01 Mayıs 2025 — ₺299 — Pro Plan</li>
-          </ul>
+        )}
+        <div className="flex gap-3 mt-2">
+          <button className="btn btn-secondary">Planı Yükselt</button>
+          <button className="btn btn-danger">İptal Et</button>
         </div>
       </div>
-    </AuthGuard>
+
+      <div className="card space-y-2">
+        <h2 className="text-lg font-semibold">📄 Fatura Geçmişi</h2>
+        {selection?.history?.length ? (
+          <ul className="text-sm text-[#7a5c36] list-disc list-inside space-y-1">
+            {selection.history.map((entry) => {
+              const historyPlan = getPlanById(entry.planId);
+              return (
+                <li key={entry.id}>
+                  {entry.billedAt} — {entry.amount} — {historyPlan ? historyPlan.name : 'Plan'}
+                  {' '}({entry.status})
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="text-sm text-[#7a5c36]">
+            Henüz fatura geçmişin bulunmuyor. Planlarını güncellemek için{' '}
+            <Link href="/plans" className="text-[#ffaa06] underline">
+              Planlar sayfasını
+            </Link>{' '}
+            ziyaret edebilirsin.
+          </p>
+        )}
+      </div>
+    </div>
   );
 }

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -1,68 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { usePlanData } from '@/hooks/usePlanData';
+
 export default function PlansPage() {
+  const { plans, selection, loading, isAuthenticated } = usePlanData();
+  const activePlanId = selection?.planId;
+
   return (
     <div className="space-y-10 max-w-5xl mx-auto">
-      <h1 className="text-3xl font-bold text-center">Üyelik Planlarımız</h1>
-      <p className="text-center text-[#7a5c36]">
-        Ducktylo platformunda senaryonuzu hayata geçirmenize yardımcı olacak
-        farklı üyelik seviyeleri sunuyoruz.
-      </p>
-
-      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {/* Student Plan */}
-        <div className="card space-y-2">
-          <h2 className="text-xl font-semibold">🎓 Student</h2>
-          <p className="text-sm">
-            Sadece <strong>@edu.tr</strong> e-postaları için geçerlidir.
+      <header className="space-y-4 text-center">
+        <h1 className="text-3xl font-bold">Üyelik Planlarımız</h1>
+        <p className="text-[#7a5c36]">
+          Ducktylo platformunda senaryonuzu hayata geçirmenize yardımcı olacak farklı
+          üyelik seviyeleri sunuyoruz.
+        </p>
+        {isAuthenticated && (
+          <p className="text-sm text-[#7a5c36]">
+            Aktif planın vurgulanmıştır, dilersen diğer seçenekleri buradan
+            karşılaştırabilirsin.
           </p>
-          <ul className="text-sm list-disc list-inside text-[#7a5c36] space-y-1 mt-2">
-            <li>Aylık 1 senaryo yükleme</li>
-            <li>Temel erişim</li>
-            <li>Özgeçmiş oluşturma</li>
-          </ul>
-          <p className="font-bold text-[#ffaa06]">₺0 / ₺49</p>
-        </div>
+        )}
+      </header>
 
-        {/* Basic Plan */}
-        <div className="card space-y-2">
-          <h2 className="text-xl font-semibold">📝 Basic</h2>
-          <p className="text-sm">Yeni başlayan senaristler için</p>
-          <ul className="text-sm list-disc list-inside text-[#7a5c36] space-y-1 mt-2">
-            <li>2 senaryo yükleme</li>
-            <li>Temel filtreleme erişimi</li>
-            <li>Mesajlaşma sistemi</li>
-          </ul>
-          <p className="font-bold text-[#ffaa06]">₺149 / ay</p>
-        </div>
+      {loading && isAuthenticated ? (
+        <p className="text-center text-[#7a5c36]">Plan bilgilerin yükleniyor...</p>
+      ) : (
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {plans.map((plan) => {
+            const isActive = isAuthenticated && plan.id === activePlanId;
 
-        {/* Pro Plan */}
-        <div className="card space-y-2">
-          <h2 className="text-xl font-semibold">💼 Pro</h2>
-          <p className="text-sm">Düzenli senaryo üretenler için</p>
-          <ul className="text-sm list-disc list-inside text-[#7a5c36] space-y-1 mt-2">
-            <li>5 senaryo</li>
-            <li>Vitrin görünürlüğü</li>
-            <li>Temsiliyet & danışmanlık</li>
-          </ul>
-          <p className="font-bold text-[#ffaa06]">₺299 / ay</p>
+            return (
+              <article
+                key={plan.id}
+                className={`card space-y-2 transition-shadow ${
+                  isActive ? 'ring-2 ring-[#ffaa06] shadow-lg' : ''
+                }`}
+                aria-current={isActive ? 'true' : undefined}
+              >
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl font-semibold">
+                    <span aria-hidden>{plan.icon}</span> {plan.name}
+                  </h2>
+                  {isActive && (
+                    <span className="inline-flex items-center rounded-full bg-[#ffaa06]/10 px-2 py-0.5 text-xs font-semibold text-[#ffaa06]">
+                      Aktif Planın
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm">{plan.tagline}</p>
+                <ul className="text-sm list-disc list-inside text-[#7a5c36] space-y-1 mt-2">
+                  {plan.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+                <p className="font-bold text-[#ffaa06]">{plan.price}</p>
+              </article>
+            );
+          })}
         </div>
-
-        {/* Top Tier Plan */}
-        <div className="card space-y-2">
-          <h2 className="text-xl font-semibold">🌟 Top Tier</h2>
-          <p className="text-sm">Sektörün profesyonelleri için</p>
-          <ul className="text-sm list-disc list-inside text-[#7a5c36] space-y-1 mt-2">
-            <li>Sınırsız senaryo</li>
-            <li>Öne çıkma</li>
-            <li>Öncelikli destek</li>
-          </ul>
-          <p className="font-bold text-[#ffaa06]">₺499 / ay</p>
-        </div>
-      </div>
+      )}
 
       <div className="text-center mt-6">
-        <a href="/auth/sign-up-writer" className="btn btn-primary">
+        <Link href="/auth/sign-up-writer" className="btn btn-primary">
           Ücretsiz Başla
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/hooks/usePlanData.ts
+++ b/hooks/usePlanData.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useMemo } from 'react';
+import { getPlans, getSelectionForRole, type Plan, type PlanSelection } from '@/lib/plans';
+import { useSession } from '@/hooks/useSession';
+
+type UsePlanDataResult = {
+  plans: Plan[];
+  selection: PlanSelection | null;
+  loading: boolean;
+  isAuthenticated: boolean;
+};
+
+export function usePlanData(): UsePlanDataResult {
+  const { session, loading } = useSession();
+  const role = session?.user?.user_metadata?.role as string | undefined;
+
+  const plans = useMemo(() => getPlans(), []);
+  const selection = useMemo(() => {
+    if (loading) return null;
+    return getSelectionForRole(role);
+  }, [loading, role]);
+
+  return {
+    plans,
+    selection,
+    loading,
+    isAuthenticated: Boolean(session),
+  };
+}

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,145 @@
+import type { Session } from '@supabase/supabase-js';
+
+export type PlanId = 'student' | 'basic' | 'pro' | 'top-tier';
+
+export type Plan = {
+  id: PlanId;
+  name: string;
+  icon: string;
+  tagline: string;
+  price: string;
+  features: string[];
+};
+
+export type BillingHistoryEntry = {
+  id: string;
+  billedAt: string;
+  amount: string;
+  planId: PlanId;
+  status: string;
+};
+
+export type PlanSelection = {
+  planId: PlanId;
+  renewsAt: string | null;
+  history: BillingHistoryEntry[];
+};
+
+const PLANS: Plan[] = [
+  {
+    id: 'student',
+    name: 'Student',
+    icon: '🎓',
+    tagline: 'Sadece @edu.tr e-postaları için geçerlidir.',
+    price: '₺0 / ₺49',
+    features: ['Aylık 1 senaryo yükleme', 'Temel erişim', 'Özgeçmiş oluşturma'],
+  },
+  {
+    id: 'basic',
+    name: 'Basic',
+    icon: '📝',
+    tagline: 'Yeni başlayan senaristler için',
+    price: '₺149 / ay',
+    features: ['2 senaryo yükleme', 'Temel filtreleme erişimi', 'Mesajlaşma sistemi'],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    icon: '💼',
+    tagline: 'Düzenli senaryo üretenler için',
+    price: '₺299 / ay',
+    features: ['5 senaryo', 'Vitrin görünürlüğü', 'Temsiliyet & danışmanlık'],
+  },
+  {
+    id: 'top-tier',
+    name: 'Top Tier',
+    icon: '🌟',
+    tagline: 'Sektörün profesyonelleri için',
+    price: '₺499 / ay',
+    features: ['Sınırsız senaryo', 'Öne çıkma', 'Öncelikli destek'],
+  },
+];
+
+const ROLE_SELECTIONS: Record<string, PlanSelection> = {
+  writer: {
+    planId: 'pro',
+    renewsAt: '31 Ağustos 2025',
+    history: [
+      {
+        id: 'writer-2025-07',
+        billedAt: '01 Temmuz 2025',
+        amount: '₺299',
+        planId: 'pro',
+        status: 'Ödendi',
+      },
+      {
+        id: 'writer-2025-06',
+        billedAt: '01 Haziran 2025',
+        amount: '₺299',
+        planId: 'pro',
+        status: 'Ödendi',
+      },
+      {
+        id: 'writer-2025-05',
+        billedAt: '01 Mayıs 2025',
+        amount: '₺299',
+        planId: 'pro',
+        status: 'Ödendi',
+      },
+    ],
+  },
+  producer: {
+    planId: 'basic',
+    renewsAt: '01 Ağustos 2025',
+    history: [
+      {
+        id: 'producer-2025-07',
+        billedAt: '01 Temmuz 2025',
+        amount: '₺149',
+        planId: 'basic',
+        status: 'Ödendi',
+      },
+      {
+        id: 'producer-2025-06',
+        billedAt: '01 Haziran 2025',
+        amount: '₺149',
+        planId: 'basic',
+        status: 'Ödendi',
+      },
+      {
+        id: 'producer-2025-05',
+        billedAt: '01 Mayıs 2025',
+        amount: '₺149',
+        planId: 'basic',
+        status: 'Ödendi',
+      },
+    ],
+  },
+};
+
+function cloneSelection(selection: PlanSelection | null): PlanSelection | null {
+  if (!selection) return null;
+
+  return {
+    ...selection,
+    history: selection.history.map((entry) => ({ ...entry })),
+  };
+}
+
+export function getPlans(): Plan[] {
+  return PLANS.map((plan) => ({ ...plan, features: [...plan.features] }));
+}
+
+export function getPlanById(planId: PlanId): Plan | undefined {
+  return PLANS.find((plan) => plan.id === planId);
+}
+
+export function getSelectionForRole(role?: string | null): PlanSelection | null {
+  if (!role) return null;
+  return cloneSelection(ROLE_SELECTIONS[role] ?? null);
+}
+
+export function getSelectionFromSession(session: Session | null): PlanSelection | null {
+  const role = session?.user?.user_metadata?.role as string | undefined;
+  return getSelectionForRole(role);
+}


### PR DESCRIPTION
## Summary
- add a shared plan data module with role-aware selections and history
- introduce a usePlanData hook to expose plan availability and the current subscription
- refactor the public plans page and dashboard billing views to render from the shared data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8e20e3d4832db9543bd04b0d2eec