### PR TITLE
Normalize producer application listing joins

### DIFF
--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -42,11 +42,22 @@ export default function ProducerApplicationsPage() {
         status,
         created_at,
         listing_id,
+        producer_listing_id,
+        request_id,
+        owner_id,
+        producer_id,
         script_id,
+        script_metadata,
         listing:v_listings_unified!inner(id, title, owner_id, source),
-        scripts!inner(id, title, genre, length, price_cents)
+        scripts!left(id, title, genre, length, price_cents)
       `)
-      .eq('owner_id', user.id)
+      .or(
+        [
+          `and(listing_id.not.is.null,listing.owner_id.eq.${user.id})`,
+          `and(producer_listing_id.not.is.null,listing.owner_id.eq.${user.id})`,
+          `and(request_id.not.is.null,listing.owner_id.eq.${user.id})`,
+        ].join(',')
+      )
       .order('created_at', { ascending: false });
 
     if (error) {
@@ -62,29 +73,72 @@ export default function ProducerApplicationsPage() {
           ? item.scripts[0]
           : item.scripts;
 
-        const normalizedLength =
-          typeof script?.length === 'number'
-            ? script.length
-            : script?.length != null
-            ? Number(script.length)
+        const scriptMetadata =
+          item.script_metadata && typeof item.script_metadata === 'object'
+            ? (item.script_metadata as Record<string, any>)
             : null;
 
-        const normalizedPrice =
-          typeof script?.price_cents === 'number'
-            ? script.price_cents
-            : script?.price_cents != null
-            ? Number(script.price_cents)
+        const rawLength =
+          script?.length ?? scriptMetadata?.length ?? null;
+        const normalizedLength =
+          typeof rawLength === 'number'
+            ? rawLength
+            : rawLength != null && !Number.isNaN(Number(rawLength))
+            ? Number(rawLength)
             : null;
+
+        const rawPrice =
+          script?.price_cents ?? scriptMetadata?.price_cents ?? null;
+        const normalizedPrice =
+          typeof rawPrice === 'number'
+            ? rawPrice
+            : rawPrice != null && !Number.isNaN(Number(rawPrice))
+            ? Number(rawPrice)
+            : null;
+
+        const rawListingId =
+          item.listing_id ??
+          item.producer_listing_id ??
+          item.request_id ??
+          listing?.id ??
+          null;
+        const resolvedListingId =
+          rawListingId != null ? String(rawListingId) : '';
+
+        const rawScriptId =
+          item.script_id ?? script?.id ?? scriptMetadata?.id ?? null;
+        const resolvedScriptId =
+          rawScriptId != null ? String(rawScriptId) : '';
+
+        const scriptTitle =
+          (script?.title != null ? String(script.title) : null) ??
+          (scriptMetadata?.title != null
+            ? String(scriptMetadata.title)
+            : '');
+
+        const scriptGenre =
+          (script?.genre != null ? String(script.genre) : null) ??
+          (scriptMetadata?.genre != null
+            ? String(scriptMetadata.genre)
+            : '');
+
+        const listingTitle =
+          listing?.title != null ? String(listing.title) : '';
+
+        const applicationId =
+          item.id != null ? String(item.id) : '';
+
+        const status = item.status != null ? String(item.status) : '';
 
         return {
-          application_id: item.id,
-          status: item.status,
+          application_id: applicationId,
+          status,
           created_at: item.created_at,
-          listing_id: item.listing_id ?? listing?.id ?? '',
-          listing_title: listing?.title ?? '',
-          script_id: item.script_id ?? script?.id ?? '',
-          script_title: script?.title ?? '',
-          script_genre: script?.genre ?? '',
+          listing_id: resolvedListingId,
+          listing_title: listingTitle,
+          script_id: resolvedScriptId,
+          script_title: scriptTitle,
+          script_genre: scriptGenre,
           length: normalizedLength,
           price_cents: normalizedPrice,
         } as ApplicationRow;


### PR DESCRIPTION
## Summary
- select explicit application identifiers and script metadata when loading producer applications
- replace the owner filter with an or-scope that matches listing/request identifiers to the joined unified listing view
- normalize script and listing mapping to fall back to stored metadata so legacy and new applications appear consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd2e384e0832d881b90b77de4ba8d