### PR TITLE
feat: load and update plans from Supabase

### DIFF
--- a/app/dashboard/producer/billing/page.tsx
+++ b/app/dashboard/producer/billing/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import AuthGuard from '@/components/AuthGuard';
 import { usePlanData } from '@/hooks/usePlanData';
@@ -14,12 +15,33 @@ export default function ProducerBillingPage() {
 }
 
 function BillingContent() {
-  const { selection, loading } = usePlanData();
+  const { selection, loading, isSaving, updatePlan } = usePlanData();
+  const [actionError, setActionError] = useState<string | null>(null);
   const plan = selection ? getPlanById(selection.planId) : undefined;
 
   if (loading) {
     return <p className="text-center text-[#7a5c36]">Plan bilgilerin yükleniyor...</p>;
   }
+
+  const handleUpgrade = async () => {
+    setActionError(null);
+    try {
+      await updatePlan('top-tier');
+    } catch (error) {
+      console.error('Plan yükseltme başarısız:', error);
+      setActionError('Plan yükseltilirken bir hata oluştu. Lütfen tekrar deneyin.');
+    }
+  };
+
+  const handleCancel = async () => {
+    setActionError(null);
+    try {
+      await updatePlan('student');
+    } catch (error) {
+      console.error('Plan iptali başarısız:', error);
+      setActionError('Plan iptal edilirken bir hata oluştu. Lütfen tekrar deneyin.');
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -47,9 +69,21 @@ function BillingContent() {
           </p>
         )}
         <div className="flex gap-3 mt-2">
-          <button className="btn btn-secondary">Planı Yükselt</button>
-          <button className="btn btn-danger">İptal Et</button>
+          <button className="btn btn-secondary" onClick={handleUpgrade} disabled={isSaving}>
+            {isSaving ? 'Güncelleniyor...' : 'Planı Yükselt'}
+          </button>
+          <button className="btn btn-danger" onClick={handleCancel} disabled={isSaving}>
+            {isSaving ? 'Güncelleniyor...' : 'İptal Et'}
+          </button>
         </div>
+        {selection?.updatedAt && (
+          <p className="text-xs text-[#7a5c36]">Son güncelleme: {selection.updatedAt}</p>
+        )}
+        {actionError && (
+          <p role="alert" className="text-sm text-red-600">
+            {actionError}
+          </p>
+        )}
       </div>
 
       <div className="card space-y-2">

--- a/app/dashboard/writer/billing/page.tsx
+++ b/app/dashboard/writer/billing/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import AuthGuard from '@/components/AuthGuard';
 import { usePlanData } from '@/hooks/usePlanData';
@@ -14,12 +15,33 @@ export default function WriterBillingPage() {
 }
 
 function BillingContent() {
-  const { selection, loading } = usePlanData();
+  const { selection, loading, isSaving, updatePlan } = usePlanData();
+  const [actionError, setActionError] = useState<string | null>(null);
   const plan = selection ? getPlanById(selection.planId) : undefined;
 
   if (loading) {
     return <p className="text-center text-[#7a5c36]">Plan bilgilerin yükleniyor...</p>;
   }
+
+  const handleUpgrade = async () => {
+    setActionError(null);
+    try {
+      await updatePlan('top-tier');
+    } catch (error) {
+      console.error('Plan yükseltme başarısız:', error);
+      setActionError('Plan yükseltilirken bir hata oluştu. Lütfen tekrar deneyin.');
+    }
+  };
+
+  const handleCancel = async () => {
+    setActionError(null);
+    try {
+      await updatePlan('student');
+    } catch (error) {
+      console.error('Plan iptali başarısız:', error);
+      setActionError('Plan iptal edilirken bir hata oluştu. Lütfen tekrar deneyin.');
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -47,9 +69,21 @@ function BillingContent() {
           </p>
         )}
         <div className="flex gap-3 mt-2">
-          <button className="btn btn-secondary">Planı Yükselt</button>
-          <button className="btn btn-danger">İptal Et</button>
+          <button className="btn btn-secondary" onClick={handleUpgrade} disabled={isSaving}>
+            {isSaving ? 'Güncelleniyor...' : 'Planı Yükselt'}
+          </button>
+          <button className="btn btn-danger" onClick={handleCancel} disabled={isSaving}>
+            {isSaving ? 'Güncelleniyor...' : 'İptal Et'}
+          </button>
         </div>
+        {selection?.updatedAt && (
+          <p className="text-xs text-[#7a5c36]">Son güncelleme: {selection.updatedAt}</p>
+        )}
+        {actionError && (
+          <p role="alert" className="text-sm text-red-600">
+            {actionError}
+          </p>
+        )}
       </div>
 
       <div className="card space-y-2">

--- a/hooks/usePlanData.ts
+++ b/hooks/usePlanData.ts
@@ -1,7 +1,16 @@
 'use client';
 
-import { useMemo } from 'react';
-import { getPlans, getSelectionForRole, type Plan, type PlanSelection } from '@/lib/plans';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createLivePlanSelection,
+  getDefaultSelectionForRole,
+  getPlans,
+  isPlanId,
+  type Plan,
+  type PlanId,
+  type PlanSelection,
+} from '@/lib/plans';
+import { supabase } from '@/lib/supabaseClient';
 import { useSession } from '@/hooks/useSession';
 
 type UsePlanDataResult = {
@@ -9,22 +18,109 @@ type UsePlanDataResult = {
   selection: PlanSelection | null;
   loading: boolean;
   isAuthenticated: boolean;
+  isSaving: boolean;
+  updatePlan: (planId: PlanId) => Promise<void>;
+  refresh: () => Promise<void>;
 };
 
 export function usePlanData(): UsePlanDataResult {
   const { session, loading } = useSession();
+  const [selection, setSelection] = useState<PlanSelection | null>(null);
+  const [planLoading, setPlanLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
   const role = session?.user?.user_metadata?.role as string | undefined;
+  const userId = session?.user?.id as string | undefined;
 
   const plans = useMemo(() => getPlans(), []);
-  const selection = useMemo(() => {
-    if (loading) return null;
-    return getSelectionForRole(role);
-  }, [loading, role]);
+
+  const applyFallbackSelection = useCallback(() => {
+    const fallback = getDefaultSelectionForRole(role) ?? null;
+    setSelection(fallback);
+  }, [role]);
+
+  const fetchSelection = useCallback(async () => {
+    if (!userId) {
+      setSelection(null);
+      return;
+    }
+
+    setPlanLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('user_plans')
+        .select('plan, updated_at')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (error) {
+        throw error;
+      }
+
+      if (data && isPlanId(data.plan)) {
+        setSelection(createLivePlanSelection(data.plan, data.updated_at ?? null));
+      } else {
+        applyFallbackSelection();
+      }
+    } catch (err) {
+      console.error('Plan bilgisi alınamadı:', err);
+      applyFallbackSelection();
+    } finally {
+      setPlanLoading(false);
+    }
+  }, [applyFallbackSelection, userId]);
+
+  useEffect(() => {
+    if (loading) return;
+
+    if (!session) {
+      setSelection(null);
+      setPlanLoading(false);
+      return;
+    }
+
+    fetchSelection();
+  }, [fetchSelection, loading, session]);
+
+  const updatePlan = useCallback(
+    async (planId: PlanId) => {
+      if (!userId) {
+        throw new Error('Kullanıcı oturumu bulunamadı.');
+      }
+
+      setIsSaving(true);
+      try {
+        const { data, error } = await supabase
+          .from('user_plans')
+          .upsert({ user_id: userId, plan: planId })
+          .select('plan, updated_at')
+          .single();
+
+        if (error) {
+          throw error;
+        }
+
+        const nextPlan = data && isPlanId(data.plan) ? data.plan : planId;
+        setSelection(createLivePlanSelection(nextPlan, data?.updated_at ?? null));
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [userId],
+  );
+
+  const refresh = useCallback(async () => {
+    if (!session || !userId) return;
+    await fetchSelection();
+  }, [fetchSelection, session, userId]);
 
   return {
     plans,
     selection,
-    loading,
+    loading: loading || planLoading,
     isAuthenticated: Boolean(session),
+    isSaving,
+    updatePlan,
+    refresh,
   };
 }

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -2,6 +2,11 @@ import type { Session } from '@supabase/supabase-js';
 
 export type PlanId = 'student' | 'basic' | 'pro' | 'top-tier';
 
+export function isPlanId(value: string | null | undefined): value is PlanId {
+  if (!value) return false;
+  return value === 'student' || value === 'basic' || value === 'pro' || value === 'top-tier';
+}
+
 export type Plan = {
   id: PlanId;
   name: string;
@@ -23,6 +28,8 @@ export type PlanSelection = {
   planId: PlanId;
   renewsAt: string | null;
   history: BillingHistoryEntry[];
+  updatedAt: string | null;
+  source: 'live' | 'default';
 };
 
 const PLANS: Plan[] = [
@@ -60,7 +67,7 @@ const PLANS: Plan[] = [
   },
 ];
 
-const ROLE_SELECTIONS: Record<string, PlanSelection> = {
+const DEFAULT_PLAN_SELECTIONS: Record<string, PlanSelection> = {
   writer: {
     planId: 'pro',
     renewsAt: '31 Ağustos 2025',
@@ -87,6 +94,8 @@ const ROLE_SELECTIONS: Record<string, PlanSelection> = {
         status: 'Ödendi',
       },
     ],
+    updatedAt: null,
+    source: 'default',
   },
   producer: {
     planId: 'basic',
@@ -114,6 +123,8 @@ const ROLE_SELECTIONS: Record<string, PlanSelection> = {
         status: 'Ödendi',
       },
     ],
+    updatedAt: null,
+    source: 'default',
   },
 };
 
@@ -135,11 +146,25 @@ export function getPlanById(planId: PlanId): Plan | undefined {
 }
 
 export function getSelectionForRole(role?: string | null): PlanSelection | null {
-  if (!role) return null;
-  return cloneSelection(ROLE_SELECTIONS[role] ?? null);
+  return getDefaultSelectionForRole(role);
 }
 
 export function getSelectionFromSession(session: Session | null): PlanSelection | null {
   const role = session?.user?.user_metadata?.role as string | undefined;
   return getSelectionForRole(role);
+}
+
+export function getDefaultSelectionForRole(role?: string | null): PlanSelection | null {
+  if (!role) return null;
+  return cloneSelection(DEFAULT_PLAN_SELECTIONS[role] ?? null);
+}
+
+export function createLivePlanSelection(planId: PlanId, updatedAt: string | null = null): PlanSelection {
+  return {
+    planId,
+    renewsAt: null,
+    history: [],
+    updatedAt,
+    source: 'live',
+  };
 }

--- a/sql/migrations/_optional_trigger_conversation.sql
+++ b/sql/migrations/_optional_trigger_conversation.sql
@@ -1,0 +1,30 @@
+-- Optional trigger to automatically create a conversation once an application is accepted.
+
+create or replace function public.ensure_conversation_on_accept()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.status = 'accepted' then
+    insert into public.conversations (application_id)
+    select new.id
+    where not exists (
+      select 1
+      from public.conversations c
+      where c.application_id = new.id
+    );
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists conversation_on_accept on public.applications;
+
+create trigger conversation_on_accept
+after insert or update on public.applications
+for each row
+when (new.status = 'accepted')
+execute function public.ensure_conversation_on_accept();

--- a/sql/migrations/mvp_user_plans.sql
+++ b/sql/migrations/mvp_user_plans.sql
@@ -1,0 +1,24 @@
+-- MVP migration to introduce per-user plan tracking
+
+create table if not exists public.user_plans (
+  user_id uuid primary key references auth.users(id),
+  plan text not null,
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.set_user_plans_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists user_plans_set_updated_at on public.user_plans;
+
+create trigger user_plans_set_updated_at
+before insert or update on public.user_plans
+for each row
+execute function public.set_user_plans_updated_at();


### PR DESCRIPTION
## Summary
- add a `user_plans` table migration with timestamp trigger plus an optional conversation-on-accept trigger
- refactor plan utilities and hook to load data from Supabase while falling back to default selections
- connect billing actions and public plan highlighting to live plan data and Supabase upserts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd2ecc3f4832da4333834a9ef78aa