### PR TITLE
Add optional trigger to auto-create conversations

### DIFF
--- a/sql/migrations/_optional_trigger_conversation.sql
+++ b/sql/migrations/_optional_trigger_conversation.sql
@@ -1,0 +1,67 @@
+-- Optional migration: auto-create conversations when applications are accepted.
+-- Apply manually if you want to automatically create a conversation (and
+-- participants, when supported) when an application's status transitions to
+-- "accepted".
+
+create or replace function public.ensure_conversation_for_accepted_application()
+returns trigger as $$
+declare
+  conversation_id uuid;
+begin
+  if new.status = 'accepted' and (old.status is distinct from new.status) then
+    select id into conversation_id
+    from public.conversations
+    where application_id = new.id;
+
+    if conversation_id is null then
+      insert into public.conversations (application_id)
+      values (new.id)
+      returning id into conversation_id;
+    end if;
+
+    if conversation_id is not null and exists (
+      select 1
+      from information_schema.tables
+      where table_schema = 'public'
+        and table_name = 'conversation_participants'
+    ) then
+      if new.writer_id is not null then
+        execute $$
+          insert into public.conversation_participants (conversation_id, user_id, role)
+          values ($1, $2, 'writer')
+          on conflict (conversation_id, user_id) do nothing
+        $$ using conversation_id, new.writer_id;
+      elsif new.user_id is not null then
+        execute $$
+          insert into public.conversation_participants (conversation_id, user_id, role)
+          values ($1, $2, 'writer')
+          on conflict (conversation_id, user_id) do nothing
+        $$ using conversation_id, new.user_id;
+      end if;
+
+      if new.owner_id is not null then
+        execute $$
+          insert into public.conversation_participants (conversation_id, user_id, role)
+          values ($1, $2, 'producer')
+          on conflict (conversation_id, user_id) do nothing
+        $$ using conversation_id, new.owner_id;
+      elsif new.producer_id is not null then
+        execute $$
+          insert into public.conversation_participants (conversation_id, user_id, role)
+          values ($1, $2, 'producer')
+          on conflict (conversation_id, user_id) do nothing
+        $$ using conversation_id, new.producer_id;
+      end if;
+    end if;
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists create_conversation_on_application_accept on public.applications;
+create trigger create_conversation_on_application_accept
+after update on public.applications
+for each row
+when (old.status is distinct from new.status and new.status = 'accepted')
+execute function public.ensure_conversation_for_accepted_application();

--- a/sql/migrations/_optional_trigger_conversation.sql
+++ b/sql/migrations/_optional_trigger_conversation.sql
@@ -1,14 +1,21 @@
--- Optional migration: auto-create conversations when applications are accepted.
--- Apply manually if you want to automatically create a conversation (and
--- participants, when supported) when an application's status transitions to
--- "accepted".
+-- Optional migration: manually apply if you want to automatically create a
+-- conversation (and participants, when supported) whenever an application's
+-- status transitions to "accepted".
 
-create or replace function public.ensure_conversation_for_accepted_application()
-returns trigger as $$
+create or replace function public.ensure_conversation_on_accept()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
 declare
   conversation_id uuid;
 begin
-  if new.status = 'accepted' and (old.status is distinct from new.status) then
+  if new.status = 'accepted' then
+    if tg_op <> 'INSERT' and old.status is not distinct from new.status then
+      return new;
+    end if;
+
     select id into conversation_id
     from public.conversations
     where application_id = new.id;
@@ -26,42 +33,35 @@ begin
         and table_name = 'conversation_participants'
     ) then
       if new.writer_id is not null then
-        execute $$
-          insert into public.conversation_participants (conversation_id, user_id, role)
-          values ($1, $2, 'writer')
-          on conflict (conversation_id, user_id) do nothing
-        $$ using conversation_id, new.writer_id;
+        insert into public.conversation_participants (conversation_id, user_id, role)
+        values (conversation_id, new.writer_id, 'writer')
+        on conflict (conversation_id, user_id) do nothing;
       elsif new.user_id is not null then
-        execute $$
-          insert into public.conversation_participants (conversation_id, user_id, role)
-          values ($1, $2, 'writer')
-          on conflict (conversation_id, user_id) do nothing
-        $$ using conversation_id, new.user_id;
+        insert into public.conversation_participants (conversation_id, user_id, role)
+        values (conversation_id, new.user_id, 'writer')
+        on conflict (conversation_id, user_id) do nothing;
       end if;
 
       if new.owner_id is not null then
-        execute $$
-          insert into public.conversation_participants (conversation_id, user_id, role)
-          values ($1, $2, 'producer')
-          on conflict (conversation_id, user_id) do nothing
-        $$ using conversation_id, new.owner_id;
+        insert into public.conversation_participants (conversation_id, user_id, role)
+        values (conversation_id, new.owner_id, 'producer')
+        on conflict (conversation_id, user_id) do nothing;
       elsif new.producer_id is not null then
-        execute $$
-          insert into public.conversation_participants (conversation_id, user_id, role)
-          values ($1, $2, 'producer')
-          on conflict (conversation_id, user_id) do nothing
-        $$ using conversation_id, new.producer_id;
+        insert into public.conversation_participants (conversation_id, user_id, role)
+        values (conversation_id, new.producer_id, 'producer')
+        on conflict (conversation_id, user_id) do nothing;
       end if;
     end if;
   end if;
 
   return new;
 end;
-$$ language plpgsql;
+$$;
 
-drop trigger if exists create_conversation_on_application_accept on public.applications;
-create trigger create_conversation_on_application_accept
-after update on public.applications
+drop trigger if exists conversation_on_accept on public.applications;
+
+create trigger conversation_on_accept
+after insert or update on public.applications
 for each row
-when (old.status is distinct from new.status and new.status = 'accepted')
-execute function public.ensure_conversation_for_accepted_application();
+when (new.status = 'accepted')
+execute function public.ensure_conversation_on_accept();


### PR DESCRIPTION
## Summary
- add an optional migration that creates a trigger to auto-create conversations when applications become accepted
- ensure participants are seeded when the optional conversation_participants table is available

## Testing
- not run (migration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbd2ee4948832d997a979c9778bef6