### PR TITLE
Fix producer writer joins to use explicit constraints

### DIFF
--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -109,7 +109,7 @@ export default function ProducerListingDetailPage() {
             status,
             created_at,
             script:scripts ( id, title, genre, length, price_cents, created_at ),
-            writer:users ( id, email )
+            writer:users!applications_writer_id_fkey ( id, email )
           `)
           .eq('owner_id', user.id)
           .or(

--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -158,7 +158,7 @@ export default function ProducerMessagesPage() {
                   created_at,
                   source
                 ),
-                writer:users!inner (
+                writer:users!applications_writer_id_fkey!inner (
                   id,
                   email
                 )

--- a/app/dashboard/producer/notifications/[id]/page.tsx
+++ b/app/dashboard/producer/notifications/[id]/page.tsx
@@ -39,7 +39,7 @@ export default function ProducerNotificationDetailPage() {
             status,
             created_at,
             script:scripts ( id, title, genre, length, price_cents, created_at ),
-            writer:users ( id, email )
+            writer:users!applications_writer_id_fkey ( id, email )
           `
         )
         .eq('id', id)

--- a/app/dashboard/producer/notifications/page.tsx
+++ b/app/dashboard/producer/notifications/page.tsx
@@ -46,7 +46,7 @@ export default function ProducerNotificationsPage() {
           status,
           created_at,
           script:scripts ( id, title, genre, length, price_cents, created_at ),
-          writer:users ( id, email )
+          writer:users!applications_writer_id_fkey ( id, email )
         `
       )
       .or(`producer_id.eq.${user.id},owner_id.eq.${user.id}`)


### PR DESCRIPTION
## Summary
- update producer listing detail to select writer using the applications_writer_id_fkey relationship
- align producer notifications and notification detail writer joins with explicit FK alias
- ensure producer messages conversation loader uses the constrained writer join to avoid ambiguous embeds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc0f437174832dba74cb8cbd9a2dde