### PR TITLE
Align plan tiers with user plans

### DIFF
--- a/app/dashboard/producer/billing/page.tsx
+++ b/app/dashboard/producer/billing/page.tsx
@@ -15,7 +15,7 @@ export default function ProducerBillingPage() {
 }
 
 function BillingContent() {
-  const { selection, loading, isSaving, updatePlan } = usePlanData();
+  const { selection, loading, isSaving, upgradePlan, downgradePlan } = usePlanData();
   const [actionError, setActionError] = useState<string | null>(null);
   const plan = selection ? getPlanById(selection.planId) : undefined;
 
@@ -26,7 +26,7 @@ function BillingContent() {
   const handleUpgrade = async () => {
     setActionError(null);
     try {
-      await updatePlan('top-tier');
+      await upgradePlan();
     } catch (error) {
       console.error('Plan yükseltme başarısız:', error);
       setActionError('Plan yükseltilirken bir hata oluştu. Lütfen tekrar deneyin.');
@@ -36,7 +36,7 @@ function BillingContent() {
   const handleCancel = async () => {
     setActionError(null);
     try {
-      await updatePlan('student');
+      await downgradePlan();
     } catch (error) {
       console.error('Plan iptali başarısız:', error);
       setActionError('Plan iptal edilirken bir hata oluştu. Lütfen tekrar deneyin.');

--- a/app/dashboard/writer/billing/page.tsx
+++ b/app/dashboard/writer/billing/page.tsx
@@ -15,7 +15,7 @@ export default function WriterBillingPage() {
 }
 
 function BillingContent() {
-  const { selection, loading, isSaving, updatePlan } = usePlanData();
+  const { selection, loading, isSaving, upgradePlan, downgradePlan } = usePlanData();
   const [actionError, setActionError] = useState<string | null>(null);
   const plan = selection ? getPlanById(selection.planId) : undefined;
 
@@ -26,7 +26,7 @@ function BillingContent() {
   const handleUpgrade = async () => {
     setActionError(null);
     try {
-      await updatePlan('top-tier');
+      await upgradePlan();
     } catch (error) {
       console.error('Plan yükseltme başarısız:', error);
       setActionError('Plan yükseltilirken bir hata oluştu. Lütfen tekrar deneyin.');
@@ -36,7 +36,7 @@ function BillingContent() {
   const handleCancel = async () => {
     setActionError(null);
     try {
-      await updatePlan('student');
+      await downgradePlan();
     } catch (error) {
       console.error('Plan iptali başarısız:', error);
       setActionError('Plan iptal edilirken bir hata oluştu. Lütfen tekrar deneyin.');

--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
+import { usePlanData } from '@/hooks/usePlanData';
 import { supabase } from '@/lib/supabaseClient';
 
 type OrderRow = {
@@ -85,6 +86,11 @@ export default function WriterDashboardPage() {
   const [applications, setApplications] = useState<ApplicationSummary[]>([]);
   const [loadingApplications, setLoadingApplications] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const {
+    selection: planSelection,
+    loading: planLoading,
+    plans: availablePlans,
+  } = usePlanData();
 
   useEffect(() => {
     let isMounted = true;
@@ -220,6 +226,11 @@ export default function WriterDashboardPage() {
     [scriptStats]
   );
 
+  const activePlan = useMemo(
+    () => availablePlans.find((plan) => plan.id === planSelection?.planId) ?? null,
+    [availablePlans, planSelection?.planId]
+  );
+
   return (
     <AuthGuard allowedRoles={['writer']}>
       <div className="space-y-8">
@@ -259,9 +270,19 @@ export default function WriterDashboardPage() {
 
           <div className="card">
             <h2 className="mb-2 text-lg font-semibold">💳 Üyelik Planın</h2>
-            <p className="text-xl font-bold text-[#7a5c36]">Pro</p>
+            <p className="text-xl font-bold text-[#7a5c36]">
+              {planLoading
+                ? 'Yükleniyor…'
+                : activePlan
+                  ? `${activePlan.icon} ${activePlan.name}`
+                  : 'Plan bilgisi bulunamadı'}
+            </p>
             <p className="text-sm text-[#7a5c36]">
-              Sonraki yenileme: 31 Ağustos 2025
+              {planLoading
+                ? 'Plan bilgilerin alınıyor.'
+                : planSelection?.renewsAt
+                  ? `Sonraki yenileme: ${planSelection.renewsAt}`
+                  : 'Yenileme tarihi henüz belirlenmedi.'}
             </p>
           </div>
 

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,10 +1,10 @@
 import type { Session } from '@supabase/supabase-js';
 
-export type PlanId = 'student' | 'basic' | 'pro' | 'top-tier';
+export type PlanId = 'free' | 'student' | 'pro' | 'top';
 
 export function isPlanId(value: string | null | undefined): value is PlanId {
   if (!value) return false;
-  return value === 'student' || value === 'basic' || value === 'pro' || value === 'top-tier';
+  return value === 'free' || value === 'student' || value === 'pro' || value === 'top';
 }
 
 export type Plan = {
@@ -34,36 +34,48 @@ export type PlanSelection = {
 
 const PLANS: Plan[] = [
   {
-    id: 'student',
-    name: 'Student',
-    icon: '🎓',
-    tagline: 'Sadece @edu.tr e-postaları için geçerlidir.',
-    price: '₺0 / ₺49',
-    features: ['Aylık 1 senaryo yükleme', 'Temel erişim', 'Özgeçmiş oluşturma'],
+    id: 'free',
+    name: 'Ücretsiz',
+    icon: '🆓',
+    tagline: 'Temel özelliklerle Ducktylo’yu deneyimleyin.',
+    price: '₺0',
+    features: [
+      'Profil oluşturma ve vitrine katılma',
+      'Aylık 1 senaryo yükleme',
+      'Temel eşleştirme önerileri',
+    ],
   },
   {
-    id: 'basic',
-    name: 'Basic',
-    icon: '📝',
-    tagline: 'Yeni başlayan senaristler için',
-    price: '₺149 / ay',
-    features: ['2 senaryo yükleme', 'Temel filtreleme erişimi', 'Mesajlaşma sistemi'],
+    id: 'student',
+    name: 'Öğrenci',
+    icon: '🎓',
+    tagline: '@edu.tr adresine sahip öğrenciler için indirimli erişim.',
+    price: '₺49 / ay',
+    features: [
+      'Aylık 3 senaryo yükleme',
+      'Öğrenci rozetli vitrin görünürlüğü',
+      'Mesajlaşma ve başvuru yönetimi',
+    ],
   },
   {
     id: 'pro',
     name: 'Pro',
     icon: '💼',
-    tagline: 'Düzenli senaryo üretenler için',
+    tagline: 'Düzenli senaryo üretenler için gelişmiş araçlar.',
     price: '₺299 / ay',
-    features: ['5 senaryo', 'Vitrin görünürlüğü', 'Temsiliyet & danışmanlık'],
+    features: [
+      'Aylık 10 senaryo yükleme',
+      'Vitrinde öne çıkarma ve analizler',
+      'Temsiliyet & danışmanlık desteği',
+    ],
   },
   {
-    id: 'top-tier',
-    name: 'Top Tier',
+    id: 'top',
+    name: 'Top',
     icon: '🌟',
-    tagline: 'Sektörün profesyonelleri için',
+    tagline: 'Ajanslar ve ekipler için sınırsız güç.',
     price: '₺499 / ay',
-    features: ['Sınırsız senaryo', 'Öne çıkma', 'Öncelikli destek'],
+    features: ['Sınırsız senaryo yükleme', 'Özel vitrin konumları', 'Öncelikli destek ve danışman'],
   },
 ];
 
@@ -98,28 +110,28 @@ const DEFAULT_PLAN_SELECTIONS: Record<string, PlanSelection> = {
     source: 'default',
   },
   producer: {
-    planId: 'basic',
+    planId: 'student',
     renewsAt: '01 Ağustos 2025',
     history: [
       {
         id: 'producer-2025-07',
         billedAt: '01 Temmuz 2025',
-        amount: '₺149',
-        planId: 'basic',
+        amount: '₺49',
+        planId: 'student',
         status: 'Ödendi',
       },
       {
         id: 'producer-2025-06',
         billedAt: '01 Haziran 2025',
-        amount: '₺149',
-        planId: 'basic',
+        amount: '₺49',
+        planId: 'student',
         status: 'Ödendi',
       },
       {
         id: 'producer-2025-05',
         billedAt: '01 Mayıs 2025',
-        amount: '₺149',
-        planId: 'basic',
+        amount: '₺49',
+        planId: 'student',
         status: 'Ödendi',
       },
     ],


### PR DESCRIPTION
## Summary
- update the plan catalog to use the free, student, pro, and top tiers that match the database constraint
- teach the plan data hook to walk plan upgrades and downgrades in order and expose helpers
- refresh billing and dashboard UI to rely on the live hook instead of hard-coded plan details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc0f4b46a0832d9f839cbe0b7c6b51