### PR TITLE
Fetch writer stats from Supabase

### DIFF
--- a/app/dashboard/writer/stats/page.tsx
+++ b/app/dashboard/writer/stats/page.tsx
@@ -1,5 +1,167 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
+import { supabase } from '@/lib/supabaseClient';
+import { useSession } from '@/hooks/useSession';
+
+type WriterStats = {
+  applicationsLast30Days: number;
+  acceptedApplications: number;
+  totalOrders: number;
+  totalOrderAmountCents: number;
+  lastFetchedAtIso: string;
+};
+
 export default function WriterStatsPage() {
+  const { session, loading: sessionLoading } = useSession();
+  const [stats, setStats] = useState<WriterStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    if (sessionLoading) {
+      return () => {
+        active = false;
+      };
+    }
+
+    const userId = session?.user?.id;
+
+    if (!userId) {
+      setStats(null);
+      setStatsLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    const fetchStats = async () => {
+      setStatsLoading(true);
+      setError(null);
+
+      try {
+        const thirtyDaysAgo = new Date();
+        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+        const thirtyDaysAgoIso = thirtyDaysAgo.toISOString();
+
+        const [applicationsLast30Response, acceptedApplicationsResponse] = await Promise.all([
+          supabase
+            .from('applications')
+            .select('id', { count: 'exact', head: true })
+            .eq('writer_id', userId)
+            .gte('created_at', thirtyDaysAgoIso),
+          supabase
+            .from('applications')
+            .select('id', { count: 'exact', head: true })
+            .eq('writer_id', userId)
+            .eq('status', 'accepted'),
+        ]);
+
+        if (applicationsLast30Response.error) {
+          throw applicationsLast30Response.error;
+        }
+
+        if (acceptedApplicationsResponse.error) {
+          throw acceptedApplicationsResponse.error;
+        }
+
+        const { data: scriptRows, error: scriptsError } = await supabase
+          .from('scripts')
+          .select('id')
+          .eq('owner_id', userId);
+
+        if (scriptsError) {
+          throw scriptsError;
+        }
+
+        const scriptIds = (scriptRows ?? []).map((row) => row.id);
+
+        let totalOrders = 0;
+        let totalOrderAmountCents = 0;
+
+        if (scriptIds.length > 0) {
+          const { data: ordersData, error: ordersError } = await supabase
+            .from('orders')
+            .select('id, amount_cents, script_id')
+            .in('script_id', scriptIds);
+
+          if (ordersError) {
+            throw ordersError;
+          }
+
+          const resolvedOrders = ordersData ?? [];
+          totalOrders = resolvedOrders.length;
+          totalOrderAmountCents = resolvedOrders.reduce(
+            (sum, order) => sum + (order.amount_cents ?? 0),
+            0
+          );
+        }
+
+        if (!active) {
+          return;
+        }
+
+        setStats({
+          applicationsLast30Days: applicationsLast30Response.count ?? 0,
+          acceptedApplications: acceptedApplicationsResponse.count ?? 0,
+          totalOrders,
+          totalOrderAmountCents,
+          lastFetchedAtIso: new Date().toISOString(),
+        });
+      } catch (fetchError) {
+        console.error('Writer stats fetch failed:', fetchError);
+        if (!active) {
+          return;
+        }
+        setError('İstatistikler yüklenirken bir sorun oluştu. Lütfen tekrar deneyin.');
+        setStats(null);
+      } finally {
+        if (active) {
+          setStatsLoading(false);
+        }
+      }
+    };
+
+    fetchStats();
+
+    return () => {
+      active = false;
+    };
+  }, [session?.user?.id, sessionLoading]);
+
+  const lastUpdatedDisplay = useMemo(() => {
+    if (!stats?.lastFetchedAtIso) {
+      return null;
+    }
+
+    const parsed = new Date(stats.lastFetchedAtIso);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+
+    return new Intl.DateTimeFormat('tr-TR', {
+      dateStyle: 'long',
+      timeStyle: 'short',
+    }).format(parsed);
+  }, [stats?.lastFetchedAtIso]);
+
+  const formatCurrency = (valueInCents: number) =>
+    new Intl.NumberFormat('tr-TR', {
+      style: 'currency',
+      currency: 'TRY',
+      minimumFractionDigits: 2,
+    }).format(valueInCents / 100);
+
+  const emptyState =
+    !!stats &&
+    stats.applicationsLast30Days === 0 &&
+    stats.acceptedApplications === 0 &&
+    stats.totalOrders === 0 &&
+    stats.totalOrderAmountCents === 0;
+
   return (
     <AuthGuard allowedRoles={['writer']}>
       <div className="space-y-6">
@@ -8,31 +170,75 @@ export default function WriterStatsPage() {
           Senaryolarının performansına dair genel bir bakış:
         </p>
 
-        <div className="grid md:grid-cols-3 gap-6">
-          {/* Görüntülenme */}
-          <div className="card text-center">
-            <h2 className="text-lg font-semibold mb-2">
-              👁️ Toplam Görüntülenme
-            </h2>
-            <p className="text-4xl font-bold text-[#0e5b4a]">234</p>
+        {statsLoading ? (
+          <div className="grid md:grid-cols-3 gap-6">
+            {[...Array(3)].map((_, index) => (
+              <div key={index} className="card text-center space-y-3 animate-pulse">
+                <div className="h-4 bg-neutral-200 rounded mx-auto w-1/2" />
+                <div className="h-10 bg-neutral-200 rounded mx-auto w-1/3" />
+                <div className="h-3 bg-neutral-100 rounded mx-auto w-2/3" />
+              </div>
+            ))}
           </div>
+        ) : error ? (
+          <p className="text-center text-red-600">{error}</p>
+        ) : stats ? (
+          <>
+            <div className="grid md:grid-cols-3 gap-6">
+              <div className="card text-center space-y-2">
+                <h2 className="text-lg font-semibold">📝 Son 30 Gündeki Başvurular</h2>
+                <p className="text-4xl font-bold text-[#0e5b4a]">
+                  {stats.applicationsLast30Days.toLocaleString('tr-TR')}
+                </p>
+                <p className="text-sm text-[#a38d6d]">
+                  {stats.applicationsLast30Days > 0
+                    ? 'Son 30 gün içinde gönderdiğin başvuru sayısı.'
+                    : 'Son 30 gün içerisinde henüz başvuru göndermedin.'}
+                </p>
+              </div>
 
-          {/* Favori */}
-          <div className="card text-center">
-            <h2 className="text-lg font-semibold mb-2">⭐ Favoriye Eklenme</h2>
-            <p className="text-4xl font-bold text-[#ffaa06]">18</p>
-          </div>
+              <div className="card text-center space-y-2">
+                <h2 className="text-lg font-semibold">✅ Kabul Edilen Başvurular</h2>
+                <p className="text-4xl font-bold text-[#ffaa06]">
+                  {stats.acceptedApplications.toLocaleString('tr-TR')}
+                </p>
+                <p className="text-sm text-[#a38d6d]">
+                  {stats.acceptedApplications > 0
+                    ? 'Prodüksiyon tarafından onaylanan başvurularının toplamı.'
+                    : 'Henüz kabul edilen bir başvurun bulunmuyor.'}
+                </p>
+              </div>
 
-          {/* Yapımcı İlgisi */}
-          <div className="card text-center">
-            <h2 className="text-lg font-semibold mb-2">🎬 Yapımcı İlgisi</h2>
-            <p className="text-4xl font-bold text-[#7a5c36]">5</p>
-          </div>
-        </div>
+              <div className="card text-center space-y-2">
+                <h2 className="text-lg font-semibold">💼 Siparişler</h2>
+                <p className="text-4xl font-bold text-[#7a5c36]">
+                  {stats.totalOrders.toLocaleString('tr-TR')}
+                </p>
+                <p className="text-sm text-[#a38d6d]">
+                  {stats.totalOrders > 0
+                    ? `Toplam kazanç: ${formatCurrency(stats.totalOrderAmountCents)}`
+                    : 'Henüz sipariş alınmadı.'}
+                </p>
+              </div>
+            </div>
 
-        <div className="text-sm text-[#a38d6d] text-center mt-4">
-          Son güncelleme: 17 Temmuz 2025
-        </div>
+            {emptyState ? (
+              <p className="text-center text-[#a38d6d]">
+                İlk istatistiklerini görmek için başvuru gönder veya senaryolarını paylaş.
+              </p>
+            ) : null}
+
+            {lastUpdatedDisplay ? (
+              <div className="text-sm text-[#a38d6d] text-center mt-4">
+                Son güncelleme: {lastUpdatedDisplay}
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <p className="text-center text-[#a38d6d]">
+            Gösterilecek istatistik bulunamadı.
+          </p>
+        )}
       </div>
     </AuthGuard>
   );


### PR DESCRIPTION
## Summary
- convert the writer stats page into a client component that loads metrics with the authenticated writer's ID
- pull recent application, accepted application, and script order totals from Supabase with loading, error, and empty states
- surface zero-activity guidance and show the last refresh timestamp for clarity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc0f4b9fb8832dae3052dd7b5423dd