### PR TITLE
Ensure conversations add producer participants via producer_id

### DIFF
--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -194,7 +194,7 @@ export default function ProducerMessagesPage() {
       try {
         const { data: application, error: applicationError } = await supabase
           .from('applications')
-          .select('id, writer_id, owner_id')
+          .select('id, writer_id, producer_id')
           .eq('id', applicationId)
           .maybeSingle();
 
@@ -207,7 +207,7 @@ export default function ProducerMessagesPage() {
         }
 
         const participantIds = new Set<string>();
-        if (application?.owner_id) participantIds.add(application.owner_id);
+        if (application?.producer_id) participantIds.add(application.producer_id);
         if (application?.writer_id) participantIds.add(application.writer_id);
 
         let ensuredUserId = fallbackUserId;

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -52,7 +52,7 @@ export default function WriterMessagesPage() {
     ) => {
       const { data: application, error: applicationError } = await supabase
         .from('applications')
-        .select('id, writer_id, owner_id')
+        .select('id, writer_id, producer_id')
         .eq('id', applicationId)
         .maybeSingle();
 
@@ -66,7 +66,7 @@ export default function WriterMessagesPage() {
 
       const participantIds = new Set<string>();
       if (application?.writer_id) participantIds.add(application.writer_id);
-      if (application?.owner_id) participantIds.add(application.owner_id);
+      if (application?.producer_id) participantIds.add(application.producer_id);
 
       let ensuredUserId = fallbackUserId;
       if (!ensuredUserId) {

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -17,7 +17,7 @@ export const ensureConversationWithParticipants = async (
 ): Promise<ConversationResult> => {
   const { data: applicationData, error: applicationFetchError } = await client
     .from('applications')
-    .select('writer_id, owner_id')
+    .select('writer_id, producer_id')
     .eq('id', applicationId)
     .single();
 
@@ -52,10 +52,10 @@ export const ensureConversationWithParticipants = async (
     });
   }
 
-  if (applicationData?.owner_id) {
+  if (applicationData?.producer_id) {
     participants.push({
       conversation_id: conversationData.id,
-      user_id: applicationData.owner_id,
+      user_id: applicationData.producer_id,
       role: 'producer',
     });
   }

--- a/sql/migrations/_optional_trigger_conversation.sql
+++ b/sql/migrations/_optional_trigger_conversation.sql
@@ -43,11 +43,7 @@ begin
         on conflict (conversation_id, user_id) do nothing;
       end if;
 
-      if new.owner_id is not null then
-        insert into public.conversation_participants (conversation_id, user_id, role)
-        values (conversation_id, new.owner_id, 'producer')
-        on conflict (conversation_id, user_id) do nothing;
-      elsif new.producer_id is not null then
+      if new.producer_id is not null then
         insert into public.conversation_participants (conversation_id, user_id, role)
         values (conversation_id, new.producer_id, 'producer')
         on conflict (conversation_id, user_id) do nothing;


### PR DESCRIPTION
## Summary
- use `producer_id` when selecting conversation participants to ensure producers are added
- update writer and producer dashboards to fetch `producer_id` instead of `owner_id`
- align the optional conversation trigger with the new `producer_id` field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccfcfe2988832da26ca3dbb357f704