### PR TITLE
Use c query param for message conversation selection

### DIFF
--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -84,7 +84,8 @@ export default function ProducerMessagesPage() {
 
   const setUrlConversation = useCallback(
     (conversationId: string | null) => {
-      const currentConversation = searchParams.get('conversation');
+      const currentConversation =
+        searchParams.get('c') ?? searchParams.get('conversation');
       const currentApplication = searchParams.get('application');
 
       if (
@@ -97,11 +98,12 @@ export default function ProducerMessagesPage() {
       const params = new URLSearchParams(searchParams.toString());
 
       if (conversationId) {
-        params.set('conversation', conversationId);
+        params.set('c', conversationId);
       } else {
-        params.delete('conversation');
+        params.delete('c');
       }
 
+      params.delete('conversation');
       params.delete('application');
 
       const query = params.toString();
@@ -317,7 +319,8 @@ export default function ProducerMessagesPage() {
       return;
     }
 
-    const conversationParam = searchParams.get('conversation');
+    const conversationParam =
+      searchParams.get('c') ?? searchParams.get('conversation');
     const applicationParam = searchParams.get('application');
 
     if (conversationParam) {

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -30,7 +30,8 @@ const toSingle = <T,>(value: T | T[] | null | undefined): T | null => {
 export default function WriterMessagesPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const conversationParam = searchParams?.get('conversation') ?? null;
+  const conversationParam =
+    searchParams?.get('c') ?? searchParams?.get('conversation') ?? null;
   const applicationParam = searchParams?.get('application') ?? null;
 
   const [userId, setUserId] = useState<string | null>(null);
@@ -239,7 +240,7 @@ export default function WriterMessagesPage() {
       if (targetApplicationId || conversationParam !== nextSelectedId) {
         const params = new URLSearchParams();
         if (nextSelectedId) {
-          params.set('conversation', nextSelectedId);
+          params.set('c', nextSelectedId);
         }
         const query = params.toString();
         router.replace(


### PR DESCRIPTION
## Summary
- accept the new `c` query parameter when loading conversations on writer and producer dashboards
- persist the selected conversation back to the URL using the `c` parameter to keep shared links consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccfcff1508832db69cd5f14e3d5bc2