### PR TITLE
Add conversation uniqueness and RLS policy migrations

### DIFF
--- a/sql/migrations/mvp_conversation_uniques.sql
+++ b/sql/migrations/mvp_conversation_uniques.sql
@@ -1,0 +1,7 @@
+-- Ensure conversations are unique per application and participant entries are deduplicated
+ALTER TABLE public.conversations
+  ADD CONSTRAINT IF NOT EXISTS conversations_application_id_key
+  UNIQUE (application_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS conversation_participants_conversation_id_user_id_idx
+  ON public.conversation_participants (conversation_id, user_id);

--- a/sql/migrations/mvp_cp_policies.sql
+++ b/sql/migrations/mvp_cp_policies.sql
@@ -1,0 +1,82 @@
+-- Reset conversation participant policies to avoid self-referencing recursion
+DO $$
+DECLARE
+  policy_record record;
+BEGIN
+  FOR policy_record IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'conversation_participants'
+  LOOP
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON public.conversation_participants',
+      policy_record.policyname
+    );
+  END LOOP;
+END $$;
+
+-- Allow writers and producers attached to the application to read conversation participants
+CREATE POLICY conversation_participants_select_policy
+  ON public.conversation_participants
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.conversations c
+      JOIN public.applications a ON a.id = c.application_id
+      WHERE c.id = conversation_participants.conversation_id
+        AND (a.writer_id = auth.uid() OR a.producer_id = auth.uid())
+    )
+  );
+
+-- Allow writers and producers to add themselves to conversations for their applications
+CREATE POLICY conversation_participants_insert_policy
+  ON public.conversation_participants
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.conversations c
+      JOIN public.applications a ON a.id = c.application_id
+      WHERE c.id = conversation_participants.conversation_id
+        AND (a.writer_id = auth.uid() OR a.producer_id = auth.uid())
+    )
+  );
+
+-- Allow updates for participants when authorized through the owning application
+CREATE POLICY conversation_participants_update_policy
+  ON public.conversation_participants
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.conversations c
+      JOIN public.applications a ON a.id = c.application_id
+      WHERE c.id = conversation_participants.conversation_id
+        AND (a.writer_id = auth.uid() OR a.producer_id = auth.uid())
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.conversations c
+      JOIN public.applications a ON a.id = c.application_id
+      WHERE c.id = conversation_participants.conversation_id
+        AND (a.writer_id = auth.uid() OR a.producer_id = auth.uid())
+    )
+  );
+
+-- Allow deletions when the actor is authorized through the application relationship
+CREATE POLICY conversation_participants_delete_policy
+  ON public.conversation_participants
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.conversations c
+      JOIN public.applications a ON a.id = c.application_id
+      WHERE c.id = conversation_participants.conversation_id
+        AND (a.writer_id = auth.uid() OR a.producer_id = auth.uid())
+    )
+  );


### PR DESCRIPTION
## Summary
- ensure conversations enforce a single row per application and deduplicate participants via unique index
- rebuild conversation participant RLS policies to authorize writer and producer access through applications

## Testing
- not run (SQL-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd22853c98832db8603689e46f565c