### PR TITLE
Guard conversations unique constraint in migration

### DIFF
--- a/sql/migrations/mvp_conversation_uniques.sql
+++ b/sql/migrations/mvp_conversation_uniques.sql
@@ -1,7 +1,17 @@
 -- Ensure conversations are unique per application and participant entries are deduplicated
-ALTER TABLE public.conversations
-  ADD CONSTRAINT IF NOT EXISTS conversations_application_id_key
-  UNIQUE (application_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'conversations_application_id_key'
+  ) THEN
+    ALTER TABLE public.conversations
+      ADD CONSTRAINT conversations_application_id_key
+      UNIQUE (application_id);
+  END IF;
+END;
+$$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS conversation_participants_conversation_id_user_id_idx
   ON public.conversation_participants (conversation_id, user_id);


### PR DESCRIPTION
## Summary
- wrap the conversations unique constraint addition in a DO block
- skip adding the constraint when it already exists while leaving the unique index untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd29a081ac832da8b4ca6c0c058e87