### PR TITLE
Add conversation participants table migration

### DIFF
--- a/supabase/migrations/20240717000000_create_conversation_participants.sql
+++ b/supabase/migrations/20240717000000_create_conversation_participants.sql
@@ -1,0 +1,13 @@
+create table if not exists public.conversation_participants (
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.conversation_participants enable row level security;
+
+create unique index if not exists conversation_participants_conversation_id_user_id_idx
+  on public.conversation_participants (conversation_id, user_id);
+
+\\ir ../../sql/migrations/mvp_cp_policies.sql


### PR DESCRIPTION
## Summary
- create a Supabase migration defining the `conversation_participants` table with cascading foreign keys and timestamps
- enable RLS, add the composite unique index, and reuse the existing policy script for access control

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd527f647c832dadb8766ef21a3f0d