### PR TITLE
Include legacy scripts in writer dashboard queries

### DIFF
--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -121,7 +121,7 @@ export default function WriterDashboardPage() {
           .select(
             'id,title,genre,length,price_cents,created_at,orders(amount_cents)'
           )
-          .eq('owner_id', user.id)
+          .or(`owner_id.eq.${user.id},user_id.eq.${user.id}`)
           .order('created_at', { ascending: false });
 
         if (scriptError) {


### PR DESCRIPTION
## Summary
- include legacy `user_id` owned scripts when loading the writer dashboard
- keep dashboard metrics aligned with the expanded script result set

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd527e7e30832da796e6099b48e331