### PR TITLE
Fix Supabase migration include command

### DIFF
--- a/supabase/migrations/20240717000000_create_conversation_participants.sql
+++ b/supabase/migrations/20240717000000_create_conversation_participants.sql
@@ -10,4 +10,4 @@ alter table public.conversation_participants enable row level security;
 create unique index if not exists conversation_participants_conversation_id_user_id_idx
   on public.conversation_participants (conversation_id, user_id);
 
-\\ir ../../sql/migrations/mvp_cp_policies.sql
+\ir ../../sql/migrations/mvp_cp_policies.sql


### PR DESCRIPTION
## Summary
- correct the conversation participants migration to use the proper `\ir` meta-command when including policy SQL

## Testing
- `npx supabase db reset` *(fails: Docker daemon unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5448b6bc832d8e1959ab803cb1f2