### PR TITLE
Update header layout and navigation styling

### DIFF
--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Fragment } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -24,24 +25,32 @@ export default function AppHeader() {
   const navigation = session ? appLinks : publicLinks;
 
   return (
-    <header className="bg-forest text-brand py-4 shadow-md">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4">
-        <Link href="/" className="flex items-center gap-2">
+    <header
+      className="bg-forest text-brand py-4 shadow-md"
+      data-test-id="HEADER_NAV_V2"
+    >
+      <div className="mx-auto flex max-w-7xl items-center px-4">
+        <Link href="/" className="flex items-center gap-3">
           <Image
             src="/ducktylo-logo.png"
             alt="ducktylo logo"
             width={120}
             height={32}
-            className="h-8 w-auto"
+            className="h-10 w-auto"
             priority
           />
-          <span className="sr-only">ducktylo</span>
+          <span className="text-lg font-semibold lowercase tracking-tight text-brand">
+            ducktylo
+          </span>
         </Link>
-        <nav className="flex items-center gap-4 text-sm font-semibold">
-          {navigation.map((link) => (
-            <Link key={link.href} href={link.href} className="hover:underline">
-              {link.label}
-            </Link>
+        <nav className="ml-auto mr-4 flex items-center text-sm font-semibold">
+          {navigation.map((link, index) => (
+            <Fragment key={link.href}>
+              {index > 0 && <span className="mx-3 text-brand/70">|</span>}
+              <Link href={link.href} className="hover:underline">
+                {link.label}
+              </Link>
+            </Fragment>
           ))}
         </nav>
         <UserMenu />


### PR DESCRIPTION
## Summary
- align the header logo with the user menu by increasing its rendered height and showing a visible "ducktylo" label
- reposition the navigation group toward the user menu and add separators between each link
- expose a HEADER_NAV_V2 data-test-id on the header wrapper for automated hooks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6593b138832d862d6112e2099fec