### PR TITLE
Match footer styling with header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,8 +22,13 @@ export default function RootLayout({
 
         <main className="max-w-7xl mx-auto px-4 py-10">{children}</main>
 
-        <footer className="text-center text-sm py-6 text-[#7a5c36] opacity-80">
-          © 2025 ducktylo. Tüm hakları saklıdır.
+        <footer
+          className="bg-forest text-brand py-4"
+          data-test-id="app-footer"
+        >
+          <div className="mx-auto max-w-7xl px-4 text-center text-sm opacity-80">
+            © 2025 ducktylo. Tüm hakları saklıdır.
+          </div>
         </footer>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- style the global footer with the same green band treatment as the header for visual symmetry
- add a regression-friendly data-test-id attribute to the footer container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce65941150832dbfb1312d4e89d492