### PR TITLE
refactor: redirect browse detail to unified scripts page

### DIFF
--- a/app/dashboard/producer/browse/[id]/page.tsx
+++ b/app/dashboard/producer/browse/[id]/page.tsx
@@ -1,165 +1,33 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
 
-export default function ScriptDetailPage() {
-  const { id } = useParams();
+export default function ProducerBrowseScriptRedirectPage() {
+  const { id } = useParams<{ id?: string }>();
   const router = useRouter();
-  const [script, setScript] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-  const [purchaseMessage, setPurchaseMessage] = useState<string | null>(null);
-  const [purchaseError, setPurchaseError] = useState<string | null>(null);
-  const [isPurchasing, setIsPurchasing] = useState(false);
-  const [hasPurchased, setHasPurchased] = useState(false);
 
   useEffect(() => {
-    const load = async () => {
-      if (!id || typeof id !== 'string') {
-        setScript(null);
-        setHasPurchased(false);
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
-      setHasPurchased(false);
-      setPurchaseMessage(null);
-      setPurchaseError(null);
-
-      try {
-        const { data, error } = await supabase
-          .from('scripts')
-          .select(
-            'id, title, genre, length, price_cents, description, created_at, owner_id'
-          )
-          .eq('id', id)
-          .single();
-
-        if (error || !data) {
-          if (error) {
-            console.error('Hata:', error.message);
-          }
-          setScript(null);
-          return;
-        }
-
-        setScript(data);
-
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser();
-
-        if (!userError && user) {
-          const { data: existingOrder, error: orderError } = await supabase
-            .from('orders')
-            .select('id, script_id, buyer_id, amount_cents, created_at')
-            .eq('script_id', id)
-            .eq('buyer_id', user.id)
-            .maybeSingle();
-
-          if (orderError) {
-            console.error('Sipariş kontrol hatası:', orderError.message);
-          } else if (existingOrder) {
-            setHasPurchased(true);
-          }
-        }
-      } catch (err) {
-        console.error('Hata:', err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    load();
-  }, [id]);
-
-  const handlePurchase = async () => {
-    if (!id || typeof id !== 'string') {
-      setPurchaseError('Geçersiz senaryo.');
-      return;
+    if (typeof id === 'string') {
+      router.replace(`/dashboard/producer/scripts/${id}`);
     }
-
-    if (!script) {
-      setPurchaseError('Satın alınacak senaryo bulunamadı.');
-      return;
-    }
-
-    setPurchaseMessage(null);
-    setPurchaseError(null);
-    setIsPurchasing(true);
-
-    try {
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (userError || !user) {
-        setPurchaseError('Satın alma işlemi için giriş yapmalısınız.');
-        return;
-      }
-
-      const { error: orderError } = await supabase.from('orders').insert({
-        script_id: id,
-        buyer_id: user.id,
-        amount_cents: script.price_cents,
-      });
-
-      if (orderError) {
-        setPurchaseError(orderError.message || 'Satın alma işlemi başarısız.');
-        return;
-      }
-
-      setPurchaseMessage('Satın alma işlemi başarıyla tamamlandı.');
-      setHasPurchased(true);
-    } catch (error) {
-      console.error('Satın alma hatası:', error);
-      setPurchaseError('Satın alma işlemi sırasında beklenmeyen bir hata oluştu.');
-    } finally {
-      setIsPurchasing(false);
-    }
-  };
-
-  if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
-  if (!script)
-    return <p className="text-sm text-red-500">Senaryo bulunamadı.</p>;
+  }, [id, router]);
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold">🎬 {script.title}</h1>
-      <p className="text-sm text-[#7a5c36]">
-        Tür: {script.genre} &middot; Süre: {script.length} &middot; Fiyat: ₺
-        {(script.price_cents / 100).toFixed(2)}
-      </p>
-
-      <div className="bg-white rounded-xl shadow p-6 border-l-4 border-[#f9c74f] space-y-4">
-        <h2 className="text-lg font-semibold">Senaryo Açıklaması</h2>
-        <p className="text-[#4a3d2f]">{script.description}</p>
-
-        <div className="pt-6 space-y-3">
-          {purchaseMessage && (
-            <p className="text-sm text-green-600">{purchaseMessage}</p>
-          )}
-          {purchaseError && (
-            <p className="text-sm text-red-600">{purchaseError}</p>
-          )}
-          <div className="flex gap-3">
-            <button
-              className="btn btn-primary"
-              onClick={handlePurchase}
-              disabled={isPurchasing || hasPurchased}
-            >
-              {hasPurchased ? 'Satın Alındı' : 'Satın Al'}
-            </button>
-            <button className="btn btn-secondary" onClick={() => router.back()}>
-              Geri Dön
-            </button>
-          </div>
-        </div>
-      </div>
+    <div
+      className="space-y-3 text-sm text-gray-600"
+      data-test-id="producer-browse-redirect"
+    >
+      <p>Senaryo detayları yeni sayfaya taşındı. Yönlendiriliyorsunuz...</p>
+      {typeof id === 'string' && (
+        <Link
+          href={`/dashboard/producer/scripts/${id}`}
+          className="text-blue-600 underline"
+        >
+          Otomatik yönlendirme gerçekleşmezse buraya tıklayın.
+        </Link>
+      )}
     </div>
   );
 }

--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -256,7 +256,7 @@ export default function BrowseScriptsPage() {
                   İlgi Göster
                 </button>
                 <Link
-                  href={`/dashboard/producer/browse/${s.id}`}
+                  href={`/dashboard/producer/scripts/${s.id}`}
                   className="btn btn-secondary"
                 >
                   Detaylar

--- a/app/dashboard/producer/scripts/[id]/page.tsx
+++ b/app/dashboard/producer/scripts/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function ProducerScriptDetailPage() {
   if (loading) {
     return (
       <AuthGuard allowedRoles={['producer']}>
-        <p>Yükleniyor...</p>
+        <div data-test-id="producer-script-detail-loading">Yükleniyor...</div>
       </AuthGuard>
     );
   }
@@ -108,7 +108,7 @@ export default function ProducerScriptDetailPage() {
   if (!script) {
     return (
       <AuthGuard allowedRoles={['producer']}>
-        <div className="space-y-3">
+        <div className="space-y-3" data-test-id="producer-script-detail-error">
           {errorMsg && (
             <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded p-3">
               {errorMsg}
@@ -125,7 +125,7 @@ export default function ProducerScriptDetailPage() {
 
   return (
     <AuthGuard allowedRoles={['producer']}>
-      <div className="space-y-6">
+      <div className="space-y-6" data-test-id="producer-script-detail-page">
         <div className="flex items-end justify-between gap-3">
           <div>
             <h1 className="text-2xl font-bold">{script.title}</h1>
@@ -184,15 +184,16 @@ export default function ProducerScriptDetailPage() {
               <p className="text-sm text-gray-600">
                 Burada PDF/dosya görüntüleme veya indirme butonu yer alacak.
               </p>
-              {/* 
+              {/*
                 İLERİDE:
                 - Supabase Storage'a 'scripts' bucketı aç.
                 - Dosya yolu olarak ör. scripts/{script.id}.pdf yükle.
-                - Burada signed URL üret: 
+                - Burada signed URL üret:
                     const { data } = await supabase
                       .storage.from('scripts')
                       .createSignedUrl(`$${script.id}.pdf`, 60);
                 - Sonra bir <a href={data?.signedUrl} className="btn btn-primary">PDF'yi İndir</a> göster.
+                TODO: Satın alma akışı tamamlandığında PDF indirme butonunu etkinleştir.
               */}
               <button className="btn btn-primary mt-2" disabled>
                 PDF’yi İndir (yakında)


### PR DESCRIPTION
## Summary
- redirect the legacy producer browse detail view to the consolidated script detail route and expose a redirect data-test-id hook
- enhance the unified script detail page with deterministic data-test-id markers and document the TODO for enabling PDF downloads post-purchase
- point browse listings at the updated route so navigation consistently lands on the consolidated detail page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce659a6dfc832d99df48b1390d48ec