### PR TITLE
Update conversation unique constraint migration

### DIFF
--- a/sql/migrations/mvp_conversation_uniques_followup.sql
+++ b/sql/migrations/mvp_conversation_uniques_followup.sql
@@ -1,4 +1,4 @@
--- Ensure conversations are unique per application and participant entries are deduplicated
+-- Ensure deployments prior to the constraint rename also define the new constraint/index names
 ALTER TABLE public.conversations
   ADD CONSTRAINT IF NOT EXISTS conversations_application_id_unique
   UNIQUE (application_id);


### PR DESCRIPTION
## Summary
- simplify the MVP conversation unique migration to use ALTER TABLE ... ADD CONSTRAINT IF NOT EXISTS
- rename the conversation participant unique index to ux_conversation_participant
- add a follow-up migration that ensures the new constraint and index names exist on already-deployed databases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce65a80cc0832d949780082f2216aa