### PR TITLE
Make conversation unique constraint addition idempotent

### DIFF
--- a/sql/migrations/mvp_conversation_uniques.sql
+++ b/sql/migrations/mvp_conversation_uniques.sql
@@ -1,7 +1,18 @@
 -- Ensure conversations are unique per application and participant entries are deduplicated
-ALTER TABLE public.conversations
-  ADD CONSTRAINT IF NOT EXISTS conversations_application_id_unique
-  UNIQUE (application_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'conversations_application_id_unique'
+          AND conrelid = 'public.conversations'::regclass
+    ) THEN
+        ALTER TABLE public.conversations
+            ADD CONSTRAINT conversations_application_id_unique
+            UNIQUE (application_id);
+    END IF;
+END
+$$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_conversation_participant
   ON public.conversation_participants (conversation_id, user_id);

--- a/sql/migrations/mvp_conversation_uniques_followup.sql
+++ b/sql/migrations/mvp_conversation_uniques_followup.sql
@@ -1,7 +1,18 @@
 -- Ensure deployments prior to the constraint rename also define the new constraint/index names
-ALTER TABLE public.conversations
-  ADD CONSTRAINT IF NOT EXISTS conversations_application_id_unique
-  UNIQUE (application_id);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'conversations_application_id_unique'
+          AND conrelid = 'public.conversations'::regclass
+    ) THEN
+        ALTER TABLE public.conversations
+            ADD CONSTRAINT conversations_application_id_unique
+            UNIQUE (application_id);
+    END IF;
+END
+$$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_conversation_participant
   ON public.conversation_participants (conversation_id, user_id);


### PR DESCRIPTION
## Summary
- wrap the conversations unique constraint creation in both migrations in a DO block that checks pg_constraint first
- keep the unique index creation while ensuring the migrations can be re-run safely

## Testing
- sudo -u postgres psql -v ON_ERROR_STOP=1 -d mvp_test -f sql/migrations/mvp_conversation_uniques.sql
- sudo -u postgres psql -v ON_ERROR_STOP=1 -d mvp_test -f sql/migrations/mvp_conversation_uniques.sql
- sudo -u postgres psql -v ON_ERROR_STOP=1 -d mvp_test -f sql/migrations/mvp_conversation_uniques_followup.sql
- sudo -u postgres psql -v ON_ERROR_STOP=1 -d mvp_fresh -f sql/migrations/mvp_conversation_uniques.sql
- sudo -u postgres psql -v ON_ERROR_STOP=1 -d mvp_fresh -f sql/migrations/mvp_conversation_uniques_followup.sql

------
https://chatgpt.com/codex/tasks/task_e_68ce9c7011b0832da7d741c2103a8671