### PR TITLE
Configure Next.js build aliases

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,20 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  experimental: {
+    serverComponentsExternalPackages: ['@supabase/supabase-js'],
+  },
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      bufferutil: false,
+      'utf-8-validate': false,
+    };
+
+    return config;
+  },
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- enable strict mode and swc minification in Next.js config
- allow `@supabase/supabase-js` as an external package for server components
- alias optional websocket dependencies to avoid missing module errors during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e8469590832d9d368f7d498e467b