### PR TITLE
Align TS and ESLint excludes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+tools/**
+scripts/**
+**/*.test.*
+**/__tests__/**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,11 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "tools/**",
+    "scripts/**",
+    "**/*.test.*",
+    "**/__tests__/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- extend the TypeScript exclude list to cover tooling, scripts, and test files alongside existing ignores
- add a matching `.eslintignore` so linting skips the same folders and glob patterns

## Testing
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d0e8482530832dab7da854fadfda96