### PR TITLE
refactor: use client-side supabase getter

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function SignInPage() {
   const router = useRouter();
+  const supabase = useMemo(getSupabaseClient, []);
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/app/auth/sign-out/page.tsx
+++ b/app/auth/sign-out/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { useEffect, useMemo } from 'react';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function SignOutPage() {
+  const supabase = useMemo(getSupabaseClient, []);
   useEffect(() => {
     const run = async () => {
       try {
@@ -17,7 +18,7 @@ export default function SignOutPage() {
       }
     };
     run();
-  }, []);
+  }, [supabase]);
 
   return (
     <main className="max-w-md mx-auto p-6 text-center">

--- a/app/auth/sign-up-producer/page.tsx
+++ b/app/auth/sign-up-producer/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { useMemo, useState } from 'react';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import { useRouter } from 'next/navigation';
 
 export default function SignUpProducerPage() {
   const router = useRouter();
+  const supabase = useMemo(getSupabaseClient, []);
   const [form, setForm] = useState({
     email: '',
     password: '',

--- a/app/auth/sign-up-writer/page.tsx
+++ b/app/auth/sign-up-writer/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function SignUpWriterPage() {
   const router = useRouter();
+  const supabase = useMemo(getSupabaseClient, []);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { useEffect, useMemo, useState } from 'react';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function DashboardIndexRedirect() {
   const [msg, setMsg] = useState('Yükleniyor…');
   const [showChoice, setShowChoice] = useState(false);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     const run = async () => {
@@ -48,7 +49,7 @@ export default function DashboardIndexRedirect() {
       }
     };
     run();
-  }, []);
+  }, [supabase]);
 
   return (
     <main className="max-w-xl mx-auto p-6 text-center">

--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { ensureConversationWithParticipants } from '@/lib/conversations';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type ApplicationRow = {
   application_id: string;
@@ -36,6 +36,7 @@ export default function ProducerApplicationsPage() {
   const [totalCount, setTotalCount] = useState(0);
   const [idFilterType, setIdFilterType] = useState<IdFilter>('all');
   const [idFilterValue, setIdFilterValue] = useState('');
+  const supabase = useMemo(getSupabaseClient, []);
 
   const fetchApplications = useCallback(async () => {
     setLoading(true);
@@ -232,7 +233,7 @@ export default function ProducerApplicationsPage() {
     }
 
     setLoading(false);
-  }, [currentPage, idFilterType, idFilterValue]);
+  }, [currentPage, idFilterType, idFilterValue, supabase]);
 
   useEffect(() => {
     fetchApplications();

--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
 type Script = {
@@ -19,6 +19,7 @@ export default function BrowseScriptsPage() {
   const [scripts, setScripts] = useState<Script[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   // Basit istemci tarafı filtre/sort state (şimdilik demo; sunucuya gönderilmiyor)
   const [search, setSearch] = useState('');
@@ -76,7 +77,7 @@ export default function BrowseScriptsPage() {
         return false;
       }
     },
-    []
+    [supabase]
   );
 
   const fetchScripts = useCallback(async () => {
@@ -99,7 +100,7 @@ export default function BrowseScriptsPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [supabase]);
 
   useEffect(() => {
     let mounted = true;
@@ -246,7 +247,7 @@ export default function BrowseScriptsPage() {
         setPendingInterestId(null);
       }
     },
-    [notifyWriterOfInterest, showToast]
+    [notifyWriterOfInterest, showToast, supabase]
   );
 
   return (

--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { ensureConversationWithParticipants } from '@/lib/conversations';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import type { Listing } from '@/types/db';
 
 type ApplicationRow = {
@@ -55,6 +55,7 @@ export default function ProducerListingDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     if (!listingId) return;
@@ -188,7 +189,7 @@ export default function ProducerListingDetailPage() {
     return () => {
       isMounted = false;
     };
-  }, [listingId]);
+  }, [listingId, supabase]);
 
   const handleDecision = async (
     applicationId: string,

--- a/app/dashboard/producer/listings/new/page.tsx
+++ b/app/dashboard/producer/listings/new/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function NewProducerListingPage() {
   const router = useRouter();
@@ -13,6 +13,7 @@ export default function NewProducerListingPage() {
   const [description, setDescription] = useState('');
   const [budget, setBudget] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -29,7 +30,7 @@ export default function NewProducerListingPage() {
     };
 
     fetchUser();
-  }, [router]);
+  }, [router, supabase]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import type { Listing } from '@/types/db';
 
 const currencyFormatter = new Intl.NumberFormat('tr-TR', {
@@ -28,6 +28,7 @@ export default function ProducerListingsPage() {
   const [listings, setListings] = useState<Listing[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     const fetchListings = async () => {
@@ -69,7 +70,7 @@ export default function ProducerListingsPage() {
     };
 
     fetchListings();
-  }, [router]);
+  }, [router, supabase]);
 
   return (
     <AuthGuard allowedRoles={['producer']}>

--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 const POLL_INTERVAL = 3000;
 
@@ -68,6 +68,7 @@ export default function ProducerMessagesPage() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const supabase = useMemo(getSupabaseClient, []);
 
   const [conversations, setConversations] = useState<ConversationRecord[]>([]);
   const [selectedConversationId, setSelectedConversationId] =
@@ -181,7 +182,7 @@ export default function ProducerMessagesPage() {
     } finally {
       setLoadingConversations(false);
     }
-  }, []);
+  }, [supabase]);
 
   useEffect(() => {
     fetchConversations();
@@ -245,7 +246,7 @@ export default function ProducerMessagesPage() {
         console.error('Konuşma katılımcıları oluşturma hatası:', error);
       }
     },
-    []
+    [supabase]
   );
 
   const ensureConversationForApplication = useCallback(
@@ -285,6 +286,7 @@ export default function ProducerMessagesPage() {
       ensureParticipantsForConversation,
       fetchConversations,
       setUrlConversation,
+      supabase,
     ]
   );
 
@@ -438,7 +440,7 @@ export default function ProducerMessagesPage() {
       if (poll) clearInterval(poll);
       if (channel) supabase.removeChannel(channel);
     };
-  }, [selectedConversationId]);
+  }, [selectedConversationId, supabase]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -479,7 +481,7 @@ export default function ProducerMessagesPage() {
     } finally {
       setSending(false);
     }
-  }, [currentUserId, input, selectedConversationId, sending]);
+  }, [currentUserId, input, selectedConversationId, sending, supabase]);
 
   const selectedConversation = useMemo(
     () =>

--- a/app/dashboard/producer/notifications/[id]/page.tsx
+++ b/app/dashboard/producer/notifications/[id]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
 import { useParams } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
 type Row = {
@@ -20,6 +20,7 @@ export default function ProducerNotificationDetailPage() {
   const [row, setRow] = useState<Row | null>(null);
   const [loading, setLoading] = useState(true);
   const [conversationId, setConversationId] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
   useEffect(() => {
     const load = async () => {
       if (!id) {
@@ -110,7 +111,7 @@ export default function ProducerNotificationDetailPage() {
     };
 
     load();
-  }, [id]);
+  }, [id, supabase]);
   const getBadge = (status: string) => {
     if (status === 'accepted')
       return (

--- a/app/dashboard/producer/notifications/page.tsx
+++ b/app/dashboard/producer/notifications/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
 type Row = {
@@ -19,12 +19,9 @@ type Row = {
 export default function ProducerNotificationsPage() {
   const [items, setItems] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
 
-  useEffect(() => {
-    load();
-  }, []);
-
-  const load = async () => {
+  const load = useCallback(async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -140,7 +137,11 @@ export default function ProducerNotificationsPage() {
       setItems(withConversations);
     }
     setLoading(false);
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/producer/page.tsx
+++ b/app/dashboard/producer/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import AuthGuard from '@/components/AuthGuard';
 import { useSession } from '@/hooks/useSession';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 const formatCurrency = (cents: number | null) => {
   if (cents == null) {
@@ -56,6 +56,7 @@ export default function ProducerDashboardPage() {
   const [listingsSummary, setListingsSummary] = useState<ListingSummary[]>([]);
   const [loadingData, setLoadingData] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     if (sessionLoading) {
@@ -238,7 +239,7 @@ export default function ProducerDashboardPage() {
     return () => {
       isCancelled = true;
     };
-  }, [session, sessionLoading]);
+  }, [session, sessionLoading, supabase]);
 
   const isLoading = sessionLoading || loadingData;
 

--- a/app/dashboard/producer/purchases/page.tsx
+++ b/app/dashboard/producer/purchases/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type OrderRow = {
   id: string;
@@ -35,12 +35,9 @@ const formatDateTime = (isoString: string) => {
 export default function ProducerPurchasesPage() {
   const [orders, setOrders] = useState<OrderRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
 
-  useEffect(() => {
-    fetchOrders();
-  }, []);
-
-  const fetchOrders = async () => {
+  const fetchOrders = useCallback(async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -86,7 +83,11 @@ export default function ProducerPurchasesPage() {
 
     setOrders(formatted);
     setLoading(false);
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    void fetchOrders();
+  }, [fetchOrders]);
 
   return (
     <AuthGuard allowedRoles={['producer']}>

--- a/app/dashboard/producer/scripts/[id]/page.tsx
+++ b/app/dashboard/producer/scripts/[id]/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import AuthGuard from '@/components/AuthGuard';
 
 type Script = {
@@ -27,6 +27,7 @@ export default function ProducerScriptDetailPage() {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [hasAccess, setHasAccess] = useState(false);
   const [script, setScript] = useState<Script | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   const fmtDate = (iso: string) =>
     new Intl.DateTimeFormat('tr-TR', {
@@ -91,7 +92,7 @@ export default function ProducerScriptDetailPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [supabase]);
 
   useEffect(() => {
     if (id) fetchAll(id);

--- a/app/dashboard/writer/listings/[id]/page.tsx
+++ b/app/dashboard/writer/listings/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import type { Listing } from '@/types/db';
 
 type WriterScriptOption = {
@@ -44,6 +44,7 @@ export default function ListingDetailPage() {
   const previousScriptIdsRef = useRef<Set<string>>(new Set());
   const previousMatchingCountRef = useRef(0);
   const listingRef = useRef<Listing | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   const normalizeGenre = (genre: string | null | undefined) =>
     genre?.trim().toLowerCase() ?? '';
@@ -90,7 +91,7 @@ export default function ListingDetailPage() {
       setLoading(false);
     };
     fetchListing();
-  }, [id]);
+  }, [id, supabase]);
 
   const fetchWriterResources = useCallback(
     async (options?: { reason?: 'initial' | 'visibility' }) => {
@@ -175,7 +176,7 @@ export default function ListingDetailPage() {
         setExistingApplication(null);
       }
     },
-    [id]
+    [id, supabase]
   );
 
   useEffect(() => {

--- a/app/dashboard/writer/listings/page.tsx
+++ b/app/dashboard/writer/listings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import type { Listing } from '@/types/db';
 
 const currency = new Intl.NumberFormat('tr-TR', {
@@ -25,6 +25,7 @@ export default function BrowseListingsPage() {
 
   const [search, setSearch] = useState('');
   const [selectedGenre, setSelectedGenre] = useState('Tüm Türler');
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     const fetchListings = async () => {
@@ -43,7 +44,7 @@ export default function BrowseListingsPage() {
       setLoading(false);
     };
     fetchListings();
-  }, []);
+  }, [supabase]);
 
   const filtered = useMemo(() => {
     let arr = [...listings];

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type ConversationSummary = {
   id: string;
@@ -44,6 +44,7 @@ export default function WriterMessagesPage() {
   const [messagesLoading, setMessagesLoading] = useState(false);
   const [input, setInput] = useState('');
   const bottomRef = useRef<HTMLDivElement>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   const ensureParticipantsForConversation = useCallback(
     async (
@@ -98,7 +99,7 @@ export default function WriterMessagesPage() {
           participantError.message
         );
       }
-    }, []);
+    }, [supabase]);
 
   useEffect(() => {
     let isActive = true;
@@ -262,6 +263,7 @@ export default function WriterMessagesPage() {
     conversationParam,
     ensureParticipantsForConversation,
     router,
+    supabase,
   ]);
 
   useEffect(() => {
@@ -331,7 +333,7 @@ export default function WriterMessagesPage() {
       clearInterval(pollId);
       supabase.removeChannel(channel);
     };
-  }, [selectedConversationId]);
+  }, [selectedConversationId, supabase]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/app/dashboard/writer/notifications/[id]/page.tsx
+++ b/app/dashboard/writer/notifications/[id]/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
 import { useParams } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
 type Row = {
@@ -20,6 +20,7 @@ export default function WriterNotificationDetailPage() {
   const [row, setRow] = useState<Row | null>(null);
   const [loading, setLoading] = useState(true);
   const [conversationId, setConversationId] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
   useEffect(() => {
     const load = async () => {
       if (!id) {
@@ -116,7 +117,7 @@ export default function WriterNotificationDetailPage() {
     };
 
     load();
-  }, [id]);
+  }, [id, supabase]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/writer/notifications/page.tsx
+++ b/app/dashboard/writer/notifications/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
 type NotificationItem = {
@@ -19,12 +19,9 @@ type NotificationItem = {
 export default function WriterNotificationsPage() {
   const [items, setItems] = useState<NotificationItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
 
-  useEffect(() => {
-    load();
-  }, []);
-
-  const load = async () => {
+  const load = useCallback(async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -144,7 +141,11 @@ export default function WriterNotificationsPage() {
       setItems(withConversations);
     }
     setLoading(false);
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
 import { usePlanData } from '@/hooks/usePlanData';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type OrderRow = {
   amount_cents: number | null;
@@ -89,6 +89,7 @@ export default function WriterDashboardPage() {
     loading: planLoading,
     plans: availablePlans,
   } = usePlanData();
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -228,7 +229,7 @@ export default function WriterDashboardPage() {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [supabase]);
 
   const scriptCount = scriptStats.length;
 

--- a/app/dashboard/writer/scripts/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/[id]/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type Script = {
   id: string;
@@ -22,6 +22,7 @@ export default function ScriptDetailPage() {
 
   const [script, setScript] = useState<Script | null>(null);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
   useEffect(() => {
     const load = async () => {
       if (!id || typeof id !== 'string') {
@@ -45,7 +46,7 @@ export default function ScriptDetailPage() {
     };
 
     load();
-  }, [id]);
+  }, [id, supabase]);
 
   if (loading) return <p className="text-sm text-gray-500">Yükleniyor...</p>;
   if (!script)

--- a/app/dashboard/writer/scripts/edit/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/edit/[id]/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function EditScriptPage() {
   const { id } = useParams();
@@ -16,6 +16,7 @@ export default function EditScriptPage() {
   const [priceCents, setPriceCents] = useState<number | ''>('');
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   const fetchScript = useCallback(async () => {
     if (!id) return;
@@ -43,7 +44,7 @@ export default function EditScriptPage() {
       setPriceCents(data.price_cents ?? '');
     }
     setLoading(false);
-  }, [id]);
+  }, [id, supabase]);
 
   useEffect(() => {
     fetchScript();

--- a/app/dashboard/writer/scripts/new/page.tsx
+++ b/app/dashboard/writer/scripts/new/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function NewScriptPage() {
   const router = useRouter();
@@ -14,6 +14,7 @@ export default function NewScriptPage() {
   const [description, setDescription] = useState('');
   const [priceCents, setPriceCents] = useState<number | ''>('');
   const [userId, setUserId] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     const getUser = async () => {
@@ -29,7 +30,7 @@ export default function NewScriptPage() {
     };
 
     getUser();
-  }, [router]);
+  }, [router, supabase]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/dashboard/writer/scripts/page.tsx
+++ b/app/dashboard/writer/scripts/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type Script = {
   id: string;
@@ -33,6 +33,7 @@ export default function MyScriptsPage() {
   const [scripts, setScripts] = useState<Script[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
+  const supabase = useMemo(getSupabaseClient, []);
 
   const fetchScripts = useCallback(async (ownerId: string, showLoading = false) => {
     if (showLoading) {
@@ -59,7 +60,7 @@ export default function MyScriptsPage() {
         setLoading(false);
       }
     }
-  }, []);
+  }, [supabase]);
 
   useEffect(() => {
     let channel: ReturnType<typeof supabase.channel> | null = null;
@@ -111,7 +112,7 @@ export default function MyScriptsPage() {
         supabase.removeChannel(channel);
       }
     };
-  }, [router, fetchScripts]);
+  }, [router, fetchScripts, supabase]);
 
   const handleDelete = async (id: string) => {
     const confirmed = confirm(

--- a/app/dashboard/writer/stats/page.tsx
+++ b/app/dashboard/writer/stats/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import { useSession } from '@/hooks/useSession';
 
 type WriterStats = {
@@ -18,6 +18,7 @@ export default function WriterStatsPage() {
   const [stats, setStats] = useState<WriterStats | null>(null);
   const [statsLoading, setStatsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     let active = true;
@@ -130,7 +131,7 @@ export default function WriterStatsPage() {
     return () => {
       active = false;
     };
-  }, [session?.user?.id, sessionLoading]);
+  }, [session?.user?.id, sessionLoading, supabase]);
 
   const lastUpdatedDisplay = useMemo(() => {
     if (!stats?.lastFetchedAtIso) {

--- a/app/dashboard/writer/suggestions/page.tsx
+++ b/app/dashboard/writer/suggestions/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
 type Application = {
@@ -23,12 +23,9 @@ type Application = {
 export default function WriterSuggestionHistoryPage() {
   const [applications, setApplications] = useState<Application[]>([]);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
 
-  useEffect(() => {
-    fetchApplications();
-  }, []);
-
-  const fetchApplications = async () => {
+  const fetchApplications = useCallback(async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -127,7 +124,11 @@ export default function WriterSuggestionHistoryPage() {
     }
 
     setLoading(false);
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    fetchApplications();
+  }, [fetchApplications]);
 
   const getBadge = (status: string) => {
     if (status === 'accepted')

--- a/app/kod kopyalamak icin demo dosya.txt
+++ b/app/kod kopyalamak icin demo dosya.txt
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type ApplicationRow = {
   application_id: string;
@@ -19,6 +19,7 @@ type ApplicationRow = {
 export default function ProducerApplicationsPage() {
   const [applications, setApplications] = useState<ApplicationRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     fetchApplications();

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 import type { Role } from '@/types/db';
 
 export default function UserMenu() {
   const router = useRouter();
+  const supabase = useMemo(getSupabaseClient, []);
   const [user, setUser] = useState<any>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [registerOpen, setRegisterOpen] = useState(false);
@@ -35,7 +36,7 @@ export default function UserMenu() {
     return () => {
       authListener.subscription.unsubscribe();
     };
-  }, []);
+  }, [supabase]);
 
   useEffect(() => {
     if (!menuOpen) {
@@ -157,7 +158,7 @@ export default function UserMenu() {
     };
 
     loadCounts();
-  }, [user]);
+  }, [supabase, user]);
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();

--- a/hooks/usePlanData.ts
+++ b/hooks/usePlanData.ts
@@ -10,7 +10,7 @@ import {
   type PlanId,
   type PlanSelection,
 } from '@/lib/plans';
-import { supabase } from '@/lib/supabaseClient';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import { useSession } from '@/hooks/useSession';
 
 type PlanUpdateInput = PlanId | 'upgrade' | 'downgrade';
@@ -35,6 +35,7 @@ export function usePlanData(): UsePlanDataResult {
 
   const role = session?.user?.user_metadata?.role as string | undefined;
   const userId = session?.user?.id as string | undefined;
+  const supabase = useMemo(getSupabaseClient, []);
 
   const order: PlanId[] = useMemo(() => ['free', 'student', 'pro', 'top'], []);
 
@@ -83,7 +84,7 @@ export function usePlanData(): UsePlanDataResult {
     } finally {
       setPlanLoading(false);
     }
-  }, [applyFallbackSelection, userId]);
+  }, [applyFallbackSelection, supabase, userId]);
 
   useEffect(() => {
     if (loading) return;
@@ -154,7 +155,7 @@ export function usePlanData(): UsePlanDataResult {
         setIsSaving(false);
       }
     },
-    [resolveTargetPlan, selection?.planId, userId],
+    [resolveTargetPlan, selection?.planId, supabase, userId],
   );
 
   const upgradePlan = useCallback(() => updatePlan('upgrade'), [updatePlan]);

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+import { useEffect, useMemo, useState } from 'react';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export function useSession() {
   const [session, setSession] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
     const getSession = async () => {
@@ -26,7 +27,7 @@ export function useSession() {
     });
 
     return () => subscription.unsubscribe();
-  }, []);
+  }, [supabase]);
 
   return { session, loading };
 }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,11 +1,25 @@
-// lib/supabaseClient.ts
-import { createClient } from '@supabase/supabase-js';
+'use client';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Supabase environment variables are not set.');
+let client: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (!client) {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      const message = 'Supabase environment variables are not set.';
+      if (process.env.NODE_ENV === 'production') {
+        console.warn(message);
+      } else {
+        throw new Error(message);
+      }
+    }
+
+    client = createClient(supabaseUrl ?? '', supabaseAnonKey ?? '');
+  }
+
+  return client;
 }
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add a lazy `getSupabaseClient` helper that warns on missing env vars while keeping Supabase usage client-only
- switch client components and hooks to memoize the Supabase client locally instead of importing a shared instance
- refresh hook dependencies to satisfy lint rules after in-component Supabase access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e84776cc832d86e7640385f3bbb1