### PR TITLE
Guard Supabase client initialization

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -18,6 +18,12 @@ export default function SignInPage() {
     setLoading(true);
     setErrorMsg('');
 
+    if (!supabase) {
+      setErrorMsg('Supabase istemcisi kullanılamıyor.');
+      setLoading(false);
+      return;
+    }
+
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
@@ -51,6 +57,17 @@ export default function SignInPage() {
 
     setLoading(false);
   };
+
+  if (!supabase) {
+    return (
+      <div className="max-w-md mx-auto py-12 space-y-6">
+        <h1 className="text-2xl font-bold text-center">🔐 Giriş Yap</h1>
+        <p className="text-red-600 text-sm text-center">
+          Supabase istemcisi oluşturulamadı. Lütfen daha sonra tekrar deneyin.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-md mx-auto py-12 space-y-6">

--- a/app/auth/sign-out/page.tsx
+++ b/app/auth/sign-out/page.tsx
@@ -12,7 +12,9 @@ export default function SignOutPage() {
         document.cookie = 'dt_role=; Path=/; Max-Age=0; SameSite=Lax';
         document.cookie = 'dt_role=; Path=/dashboard; Max-Age=0; SameSite=Lax';
         // supabase oturumunu kapat
-        await supabase.auth.signOut();
+        if (supabase) {
+          await supabase.auth.signOut();
+        }
       } finally {
         window.location.href = '/';
       }

--- a/app/auth/sign-up-producer/page.tsx
+++ b/app/auth/sign-up-producer/page.tsx
@@ -23,6 +23,12 @@ export default function SignUpProducerPage() {
     setLoading(true);
     setError(null);
 
+    if (!supabase) {
+      setError('Supabase istemcisi kullanılamıyor.');
+      setLoading(false);
+      return;
+    }
+
     // Supabase auth'a kullanıcıyı ekle
     const { data, error: signUpError } = await supabase.auth.signUp({
       email: form.email,

--- a/app/auth/sign-up-writer/page.tsx
+++ b/app/auth/sign-up-writer/page.tsx
@@ -17,6 +17,12 @@ export default function SignUpWriterPage() {
     setLoading(true);
     setErrorMsg('');
 
+    if (!supabase) {
+      setErrorMsg('Supabase istemcisi kullanılamıyor.');
+      setLoading(false);
+      return;
+    }
+
     // 1. Supabase Auth kaydı
     const { data, error } = await supabase.auth.signUp({
       email,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,6 +9,12 @@ export default function DashboardIndexRedirect() {
   const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
+    if (!supabase) {
+      setShowChoice(true);
+      setMsg('Supabase istemcisi kullanılamıyor.');
+      return;
+    }
+
     const run = async () => {
       try {
         const { data: ures, error: uerr } = await supabase.auth.getUser();

--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -40,6 +40,14 @@ export default function ProducerApplicationsPage() {
 
   const fetchApplications = useCallback(async () => {
     setLoading(true);
+
+    if (!supabase) {
+      setApplications([]);
+      setTotalCount(0);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -255,6 +263,11 @@ export default function ProducerApplicationsPage() {
   };
 
   const handleDecision = async (applicationId: string, decision: Decision) => {
+    if (!supabase) {
+      alert('Supabase istemcisi kullanılamıyor.');
+      return;
+    }
+
     const { error: updateError } = await supabase
       .from('applications')
       .update({ status: decision })

--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -56,6 +56,10 @@ export default function BrowseScriptsPage() {
     async (params: { writerId: string; script: Script; producerId: string }) => {
       const { writerId, script, producerId } = params;
 
+      if (!supabase) {
+        return false;
+      }
+
       try {
         const { error } = await supabase.rpc('enqueue_notification', {
           recipient_id: writerId,
@@ -83,6 +87,14 @@ export default function BrowseScriptsPage() {
   const fetchScripts = useCallback(async () => {
     setLoading(true);
     setErrorMsg(null);
+
+    if (!supabase) {
+      setScripts([]);
+      setErrorMsg('Supabase istemcisi kullanılamıyor.');
+      setLoading(false);
+      return;
+    }
+
     try {
       const { data, error } = await supabase
         .from('scripts')
@@ -190,6 +202,10 @@ export default function BrowseScriptsPage() {
     async (script: Script) => {
       setPendingInterestId(script.id);
       try {
+        if (!supabase) {
+          throw new Error('Supabase istemcisi kullanılamıyor.');
+        }
+
         const {
           data: { user },
           error: authError,

--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -67,6 +67,12 @@ export default function ProducerListingDetailPage() {
       setError(null);
       setApplications([]);
 
+      if (!supabase) {
+        setError('Supabase istemcisi kullanılamıyor.');
+        setLoading(false);
+        return;
+      }
+
       try {
         const {
           data: { user },
@@ -196,6 +202,12 @@ export default function ProducerListingDetailPage() {
     decision: 'accepted' | 'rejected'
   ) => {
     setUpdatingId(applicationId);
+
+    if (!supabase) {
+      alert('Supabase istemcisi kullanılamıyor.');
+      setUpdatingId(null);
+      return;
+    }
 
     const { error: updateError } = await supabase
       .from('applications')

--- a/app/dashboard/producer/listings/new/page.tsx
+++ b/app/dashboard/producer/listings/new/page.tsx
@@ -17,6 +17,11 @@ export default function NewProducerListingPage() {
 
   useEffect(() => {
     const fetchUser = async () => {
+      if (!supabase) {
+        setOwnerId(null);
+        return;
+      }
+
       const {
         data: { user },
       } = await supabase.auth.getUser();
@@ -36,6 +41,11 @@ export default function NewProducerListingPage() {
     event.preventDefault();
 
     if (!ownerId) return;
+
+    if (!supabase) {
+      alert('Supabase istemcisi kullanılamıyor.');
+      return;
+    }
 
     setSubmitting(true);
 

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -35,6 +35,13 @@ export default function ProducerListingsPage() {
       setLoading(true);
       setError(null);
 
+      if (!supabase) {
+        setListings([]);
+        setError('Supabase istemcisi kullanılamıyor.');
+        setLoading(false);
+        return;
+      }
+
       const {
         data: { user },
         error: authError,

--- a/app/dashboard/producer/notifications/[id]/page.tsx
+++ b/app/dashboard/producer/notifications/[id]/page.tsx
@@ -27,6 +27,11 @@ export default function ProducerNotificationDetailPage() {
         setLoading(false);
         return;
       }
+
+      if (!supabase) {
+        setLoading(false);
+        return;
+      }
       const { data, error } = await supabase
         .from('applications')
         .select(

--- a/app/dashboard/producer/notifications/page.tsx
+++ b/app/dashboard/producer/notifications/page.tsx
@@ -22,6 +22,12 @@ export default function ProducerNotificationsPage() {
   const supabase = useMemo(getSupabaseClient, []);
 
   const load = useCallback(async () => {
+    if (!supabase) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/app/dashboard/producer/page.tsx
+++ b/app/dashboard/producer/page.tsx
@@ -80,6 +80,16 @@ export default function ProducerDashboardPage() {
         return;
       }
 
+      if (!supabase) {
+        if (!isCancelled) {
+          setOrders([]);
+          setListingsSummary([]);
+          setError('Supabase istemcisi kullanılamıyor.');
+          setLoadingData(false);
+        }
+        return;
+      }
+
       try {
         const [ordersResponse, listingsResponse, applicationsResponse] =
           await Promise.all([

--- a/app/dashboard/producer/purchases/page.tsx
+++ b/app/dashboard/producer/purchases/page.tsx
@@ -38,6 +38,12 @@ export default function ProducerPurchasesPage() {
   const supabase = useMemo(getSupabaseClient, []);
 
   const fetchOrders = useCallback(async () => {
+    if (!supabase) {
+      setOrders([]);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/app/dashboard/producer/scripts/[id]/page.tsx
+++ b/app/dashboard/producer/scripts/[id]/page.tsx
@@ -50,6 +50,11 @@ export default function ProducerScriptDetailPage() {
       setLoading(true);
       setErrorMsg(null);
 
+      if (!supabase) {
+        setErrorMsg('Supabase istemcisi kullanılamıyor.');
+        return;
+      }
+
       // 1) Giriş yapan yapımcıyı al
       const {
         data: { user },

--- a/app/dashboard/writer/listings/[id]/page.tsx
+++ b/app/dashboard/writer/listings/[id]/page.tsx
@@ -77,6 +77,11 @@ export default function ListingDetailPage() {
         return;
       }
 
+      if (!supabase) {
+        setLoading(false);
+        return;
+      }
+
       const { data, error } = await supabase
         .from('v_listings_unified')
         .select(
@@ -96,6 +101,10 @@ export default function ListingDetailPage() {
   const fetchWriterResources = useCallback(
     async (options?: { reason?: 'initial' | 'visibility' }) => {
       if (!id) return;
+
+      if (!supabase) {
+        return;
+      }
 
       const {
         data: { user },
@@ -265,6 +274,11 @@ export default function ListingDetailPage() {
 
     if (!listing) {
       alert('İlan bilgisi alınamadı.');
+      return;
+    }
+
+    if (!supabase) {
+      alert('Supabase istemcisi kullanılamıyor.');
       return;
     }
 

--- a/app/dashboard/writer/listings/page.tsx
+++ b/app/dashboard/writer/listings/page.tsx
@@ -29,6 +29,13 @@ export default function BrowseListingsPage() {
 
   useEffect(() => {
     const fetchListings = async () => {
+      if (!supabase) {
+        setLoading(false);
+        setError('Supabase istemcisi kullanılamıyor.');
+        setListings([]);
+        return;
+      }
+
       setLoading(true);
       setError(null);
       const { data, error } = await supabase

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -52,6 +52,10 @@ export default function WriterMessagesPage() {
       applicationId: string,
       fallbackUserId: string | null
     ) => {
+      if (!supabase) {
+        return;
+      }
+
       const { data: application, error: applicationError } = await supabase
         .from('applications')
         .select('id, writer_id, producer_id')
@@ -105,6 +109,14 @@ export default function WriterMessagesPage() {
     let isActive = true;
 
     const loadConversations = async () => {
+      if (!supabase) {
+        setConversations([]);
+        setConversationsLoading(false);
+        setSelectedConversationId(null);
+        setUserId(null);
+        return;
+      }
+
       setConversationsLoading(true);
 
       const {
@@ -276,6 +288,13 @@ export default function WriterMessagesPage() {
     let isActive = true;
 
     const fetchMessages = async (showSpinner = false) => {
+      if (!supabase) {
+        if (showSpinner) {
+          setMessagesLoading(false);
+        }
+        return;
+      }
+
       if (showSpinner) {
         setMessagesLoading(true);
       }
@@ -301,6 +320,12 @@ export default function WriterMessagesPage() {
     };
 
     fetchMessages(true);
+
+    if (!supabase) {
+      return () => {
+        isActive = false;
+      };
+    }
 
     const channel = supabase
       .channel(`writer-conversation-${selectedConversationId}`)
@@ -331,7 +356,7 @@ export default function WriterMessagesPage() {
     return () => {
       isActive = false;
       clearInterval(pollId);
-      supabase.removeChannel(channel);
+      supabase?.removeChannel(channel);
     };
   }, [selectedConversationId, supabase]);
 
@@ -367,6 +392,11 @@ export default function WriterMessagesPage() {
     const text = input.trim();
     if (!text) return;
     if (!userId) return;
+
+    if (!supabase) {
+      console.error('Supabase istemcisi mevcut değil. Mesaj gönderilemedi.');
+      return;
+    }
 
     const { error } = await supabase.from('messages').insert({
       conversation_id: selectedConversationId,

--- a/app/dashboard/writer/notifications/[id]/page.tsx
+++ b/app/dashboard/writer/notifications/[id]/page.tsx
@@ -27,6 +27,11 @@ export default function WriterNotificationDetailPage() {
         setLoading(false);
         return;
       }
+
+      if (!supabase) {
+        setLoading(false);
+        return;
+      }
       const { data, error } = await supabase
         .from('applications')
         .select(

--- a/app/dashboard/writer/notifications/page.tsx
+++ b/app/dashboard/writer/notifications/page.tsx
@@ -22,6 +22,12 @@ export default function WriterNotificationsPage() {
   const supabase = useMemo(getSupabaseClient, []);
 
   const load = useCallback(async () => {
+    if (!supabase) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -99,6 +99,15 @@ export default function WriterDashboardPage() {
       setLoadingApplications(true);
       setErrorMessage(null);
 
+      if (!supabase) {
+        setScriptStats([]);
+        setApplications([]);
+        setLoadingScripts(false);
+        setLoadingApplications(false);
+        setErrorMessage('Supabase istemcisi kullanılamıyor.');
+        return;
+      }
+
       try {
         const {
           data: { user },

--- a/app/dashboard/writer/scripts/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/[id]/page.tsx
@@ -29,6 +29,11 @@ export default function ScriptDetailPage() {
         setLoading(false);
         return;
       }
+
+      if (!supabase) {
+        setLoading(false);
+        return;
+      }
       const { data, error } = await supabase
         .from('scripts')
         .select(

--- a/app/dashboard/writer/scripts/edit/[id]/page.tsx
+++ b/app/dashboard/writer/scripts/edit/[id]/page.tsx
@@ -22,6 +22,13 @@ export default function EditScriptPage() {
     if (!id) return;
 
     setErrorMessage(null);
+
+    if (!supabase) {
+      setErrorMessage('Supabase istemcisi kullanılamıyor.');
+      setLoading(false);
+      return;
+    }
+
     const { data, error } = await supabase
       .from('scripts')
       .select(
@@ -52,6 +59,11 @@ export default function EditScriptPage() {
 
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!supabase) {
+      alert('Supabase istemcisi kullanılamıyor.');
+      return;
+    }
 
     const { error } = await supabase
       .from('scripts')

--- a/app/dashboard/writer/scripts/new/page.tsx
+++ b/app/dashboard/writer/scripts/new/page.tsx
@@ -18,6 +18,11 @@ export default function NewScriptPage() {
 
   useEffect(() => {
     const getUser = async () => {
+      if (!supabase) {
+        setUserId(null);
+        return;
+      }
+
       const {
         data: { user },
       } = await supabase.auth.getUser();
@@ -35,6 +40,11 @@ export default function NewScriptPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!userId) return;
+
+    if (!supabase) {
+      alert('Supabase istemcisi kullanılamıyor.');
+      return;
+    }
 
     const { error } = await supabase.from('scripts').insert([
       {

--- a/app/dashboard/writer/stats/page.tsx
+++ b/app/dashboard/writer/stats/page.tsx
@@ -39,7 +39,23 @@ export default function WriterStatsPage() {
       };
     }
 
+    if (!supabase) {
+      setStats(null);
+      setStatsLoading(false);
+      setError('Supabase istemcisi kullanılamıyor.');
+      return () => {
+        active = false;
+      };
+    }
+
     const fetchStats = async () => {
+      if (!supabase) {
+        setStats(null);
+        setStatsLoading(false);
+        setError('Supabase istemcisi kullanılamıyor.');
+        return;
+      }
+
       setStatsLoading(true);
       setError(null);
 

--- a/app/dashboard/writer/suggestions/page.tsx
+++ b/app/dashboard/writer/suggestions/page.tsx
@@ -26,6 +26,12 @@ export default function WriterSuggestionHistoryPage() {
   const supabase = useMemo(getSupabaseClient, []);
 
   const fetchApplications = useCallback(async () => {
+    if (!supabase) {
+      setApplications([]);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/app/kod kopyalamak icin demo dosya.txt
+++ b/app/kod kopyalamak icin demo dosya.txt
@@ -26,6 +26,12 @@ export default function ProducerApplicationsPage() {
   }, []);
 
   const fetchApplications = async () => {
+    if (!supabase) {
+      setApplications([]);
+      setLoading(false);
+      return;
+    }
+
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -20,6 +20,10 @@ export default function UserMenu() {
   const [chatCount, setChatCount] = useState<number>(0); // Sohbet (accepted başvuru) sayacı
 
   useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
     const getUser = async () => {
       const { data } = await supabase.auth.getUser();
       setUser(data?.user || null);
@@ -46,6 +50,10 @@ export default function UserMenu() {
 
   // Sayaçları role’e göre yükle
   useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
     const loadCounts = async () => {
       if (!user) return;
 
@@ -161,6 +169,10 @@ export default function UserMenu() {
   }, [supabase, user]);
 
   const handleSignOut = async () => {
+    if (!supabase) {
+      return;
+    }
+
     await supabase.auth.signOut();
     setUser(null);
     router.push('/');
@@ -242,6 +254,12 @@ export default function UserMenu() {
 
   const handleRoleChange = async (nextRole: Role) => {
     if (!user || role === nextRole) {
+      setRoleMenuOpen(false);
+      return;
+    }
+
+    if (!supabase) {
+      console.error('Supabase istemcisi bulunamadı.');
       setRoleMenuOpen(false);
       return;
     }

--- a/hooks/usePlanData.ts
+++ b/hooks/usePlanData.ts
@@ -61,6 +61,13 @@ export function usePlanData(): UsePlanDataResult {
       return;
     }
 
+    if (!supabase) {
+      console.warn('Supabase client is not available. Falling back to defaults.');
+      applyFallbackSelection();
+      setPlanLoading(false);
+      return;
+    }
+
     setPlanLoading(true);
     try {
       const { data, error } = await supabase
@@ -124,6 +131,11 @@ export function usePlanData(): UsePlanDataResult {
 
   const updatePlan = useCallback(
     async (target: PlanUpdateInput) => {
+      if (!supabase) {
+        console.warn('Supabase client is not available.');
+        return;
+      }
+
       if (!userId) {
         throw new Error('Kullanıcı oturumu bulunamadı.');
       }

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -9,6 +9,12 @@ export function useSession() {
   const supabase = useMemo(getSupabaseClient, []);
 
   useEffect(() => {
+    if (!supabase) {
+      setSession(null);
+      setLoading(false);
+      return;
+    }
+
     const getSession = async () => {
       const {
         data: { session },

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -4,22 +4,26 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 let client: SupabaseClient | null = null;
 
-export function getSupabaseClient(): SupabaseClient {
-  if (!client) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseAnonKey) {
-      const message = 'Supabase environment variables are not set.';
-      if (process.env.NODE_ENV === 'production') {
-        console.warn(message);
-      } else {
-        throw new Error(message);
-      }
-    }
-
-    client = createClient(supabaseUrl ?? '', supabaseAnonKey ?? '');
+export function getSupabaseClient(): SupabaseClient | null {
+  if (client) {
+    return client;
   }
 
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    const message = 'Supabase environment variables are not set.';
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(message);
+    } else {
+      console.warn(message);
+    }
+
+    return null;
+  }
+
+  client = createClient(supabaseUrl, supabaseAnonKey);
   return client;
 }


### PR DESCRIPTION
## Summary
- stop creating a Supabase client when env vars are missing and surface warnings instead
- update hooks and UI entry points to gracefully handle a missing Supabase client during SSR/prerender flows
- add null guards across dashboards, auth pages, and menus so interactive logic only runs when the client exists

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0f5a3a734832da04bc4285a499f47