### PR TITLE
Ensure root layout stretches full height

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,11 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   @apply bg-[#faf3e0] text-[#7a5c36] font-sans;
   line-height: 1.6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,12 +15,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="tr">
-      <body className="min-h-screen bg-[#faf3e0] text-[#7a5c36] font-sans">
+      <body className="flex min-h-screen flex-col bg-[#faf3e0] text-[#7a5c36] font-sans">
         <TabTitleHandler />
 
         <AppHeader />
 
-        <main className="max-w-7xl mx-auto px-4 py-10">{children}</main>
+        <main className="flex-1 max-w-7xl mx-auto px-4 py-10">{children}</main>
 
         <footer
           className="bg-forest text-brand py-4"


### PR DESCRIPTION
## Summary
- update the app layout to use a flex column body with a flexed main region
- ensure Safari respects full-height layout by applying 100% height to html and body

## Testing
- npm run test -- -u
- npm run dev (manual)


------
https://chatgpt.com/codex/tasks/task_e_68d543056738832dbfe088fa0519ff02