### PR TITLE
Refactor auth sign-up pages with shared card

### DIFF
--- a/app/auth/sign-up-producer/page.tsx
+++ b/app/auth/sign-up-producer/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { getSupabaseClient } from '@/lib/supabaseClient';
 import { useRouter } from 'next/navigation';
+
+import { AuthCard } from '@/components/AuthCard';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function SignUpProducerPage() {
   const router = useRouter();
@@ -12,7 +14,7 @@ export default function SignUpProducerPage() {
     password: '',
   });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -21,83 +23,80 @@ export default function SignUpProducerPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
-    setError(null);
+    setErrorMsg('');
 
     if (!supabase) {
-      setError('Supabase istemcisi kullanılamıyor.');
+      setErrorMsg('Supabase istemcisi kullanılamıyor.');
       setLoading(false);
       return;
     }
 
-    // Supabase auth'a kullanıcıyı ekle
     const { data, error: signUpError } = await supabase.auth.signUp({
       email: form.email,
       password: form.password,
+      options: { data: { role: 'producer' } },
     });
 
     if (signUpError) {
-      setError(signUpError.message);
+      setErrorMsg(signUpError.message);
       setLoading(false);
       return;
     }
 
-    // Ardından 'users' tablosuna da ekle
-    const { error: insertError } = await supabase.from('users').insert([
-      {
-        id: data.user?.id,
-        email: form.email,
-        role: 'producer', // bu sayfada sabit 'producer'
-      },
-    ]);
+    const { error: insertError } = await supabase.from('users').insert({
+      id: data.user?.id,
+      email: form.email,
+      role: 'producer',
+    });
 
     if (insertError) {
-      setError(insertError.message);
+      setErrorMsg(insertError.message);
       setLoading(false);
       return;
     }
 
-    router.push('/auth/sign-in'); // kayıt sonrası giriş sayfasına yönlendir
+    router.push('/auth/sign-in');
   };
 
   return (
-    <div className="space-y-6 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold">Yapımcı Olarak Kayıt Ol</h1>
+    <section className="py-12">
+      <AuthCard title="Yapımcı Olarak Kayıt Ol">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block font-semibold mb-1">E-posta</label>
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded-lg border p-3"
+              required
+            />
+          </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block font-semibold mb-1">E-posta</label>
-          <input
-            type="email"
-            name="email"
-            value={form.email}
-            onChange={handleChange}
-            className="w-full p-3 border rounded-lg"
-            required
-          />
-        </div>
+          <div>
+            <label className="block font-semibold mb-1">Şifre</label>
+            <input
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded-lg border p-3"
+              required
+            />
+          </div>
 
-        <div>
-          <label className="block font-semibold mb-1">Şifre</label>
-          <input
-            type="password"
-            name="password"
-            value={form.password}
-            onChange={handleChange}
-            className="w-full p-3 border rounded-lg"
-            required
-          />
-        </div>
+          {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
 
-        {error && <p className="text-red-600 text-sm">{error}</p>}
-
-        <button
-          type="submit"
-          className="btn btn-primary w-full"
-          disabled={loading}
-        >
-          {loading ? 'Kayıt Olunuyor...' : 'Kayıt Ol'}
-        </button>
-      </form>
-    </div>
+          <button
+            type="submit"
+            className="btn btn-primary w-full"
+            disabled={loading}
+          >
+            {loading ? 'Kaydoluyor...' : 'Kayıt Ol'}
+          </button>
+        </form>
+      </AuthCard>
+    </section>
   );
 }

--- a/app/auth/sign-up-writer/page.tsx
+++ b/app/auth/sign-up-writer/page.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+
+import { AuthCard } from '@/components/AuthCard';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 
 export default function SignUpWriterPage() {
@@ -23,11 +25,10 @@ export default function SignUpWriterPage() {
       return;
     }
 
-    // 1. Supabase Auth kaydı
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
-      options: { data: { role: 'writer' } }, // user_metadata
+      options: { data: { role: 'writer' } },
     });
 
     if (error) {
@@ -43,7 +44,6 @@ export default function SignUpWriterPage() {
       return;
     }
 
-    // 2. public.users tablosuna ekle
     const { error: insertError } = await supabase.from('users').insert({
       id: userId,
       email,
@@ -60,43 +60,42 @@ export default function SignUpWriterPage() {
   };
 
   return (
-    <div className="space-y-6 max-w-md mx-auto py-12">
-      <h1 className="text-2xl font-bold text-center">
-        Senarist Olarak Kayıt Ol
-      </h1>
-      <form className="space-y-4" onSubmit={handleSignUp}>
-        <div>
-          <label className="block font-semibold mb-1">E-posta</label>
-          <input
-            type="email"
-            className="w-full p-3 border rounded-lg"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
+    <section className="py-12">
+      <AuthCard title="Senarist Olarak Kayıt Ol">
+        <form className="space-y-4" onSubmit={handleSignUp}>
+          <div>
+            <label className="block font-semibold mb-1">E-posta</label>
+            <input
+              type="email"
+              className="w-full rounded-lg border p-3"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
 
-        <div>
-          <label className="block font-semibold mb-1">Şifre</label>
-          <input
-            type="password"
-            className="w-full p-3 border rounded-lg"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
+          <div>
+            <label className="block font-semibold mb-1">Şifre</label>
+            <input
+              type="password"
+              className="w-full rounded-lg border p-3"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
 
-        {errorMsg && <p className="text-red-600 text-sm">{errorMsg}</p>}
+          {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
 
-        <button
-          type="submit"
-          className="btn btn-primary w-full"
-          disabled={loading}
-        >
-          {loading ? 'Kaydoluyor...' : 'Kayıt Ol'}
-        </button>
-      </form>
-    </div>
+          <button
+            type="submit"
+            className="btn btn-primary w-full"
+            disabled={loading}
+          >
+            {loading ? 'Kaydoluyor...' : 'Kayıt Ol'}
+          </button>
+        </form>
+      </AuthCard>
+    </section>
   );
 }

--- a/components/AuthCard.tsx
+++ b/components/AuthCard.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+interface AuthCardProps {
+  title: string;
+  children: ReactNode;
+  description?: ReactNode;
+  footer?: ReactNode;
+}
+
+export function AuthCard({ title, description, children, footer }: AuthCardProps) {
+  return (
+    <div className="mx-auto max-w-md space-y-6 rounded-lg bg-white p-6 shadow-sm">
+      <div className="space-y-2 text-center">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {description && <p className="text-sm text-forest/80">{description}</p>}
+      </div>
+      <div className="space-y-4">{children}</div>
+      {footer && <div className="pt-2 text-center text-sm text-forest/80">{footer}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an `AuthCard` component to centralize shared auth layout padding and typography
- refactor the writer and producer sign-up screens to render inside the new card and align button/error styling

## Testing
- npm run lint
- npx lighthouse http://localhost:3000/auth/sign-up-writer --only-categories=accessibility --port=9222 --skip-autolaunch --output=json --output-path=./lighthouse-writer.json --quiet
- npx lighthouse http://localhost:3000/auth/sign-up-producer --only-categories=accessibility --port=9222 --skip-autolaunch --output=json --output-path=./lighthouse-producer.json --quiet

------
https://chatgpt.com/codex/tasks/task_e_68d543047a54832d938ca23b19430185