### PR TITLE
Add VAT breakdown to producer purchases

### DIFF
--- a/__tests__/producerPurchases.test.ts
+++ b/__tests__/producerPurchases.test.ts
@@ -1,0 +1,20 @@
+import { calculateTaxBreakdown } from '@/app/dashboard/producer/purchases/page';
+
+describe('calculateTaxBreakdown', () => {
+  it('returns null when price is null', () => {
+    expect(calculateTaxBreakdown(null)).toBeNull();
+  });
+
+  it('calculates net, vat and gross values in cents', () => {
+    const mockPrices = [
+      { price: 10000, expected: { netCents: 10000, vatCents: 2000, grossCents: 12000 } },
+      { price: 33333, expected: { netCents: 33333, vatCents: 6667, grossCents: 40000 } },
+    ];
+
+    mockPrices.forEach(({ price, expected }) => {
+      const breakdown = calculateTaxBreakdown(price);
+      expect(breakdown).not.toBeNull();
+      expect(breakdown).toMatchObject(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- calculate a VAT breakdown for each producer purchase and expose it to the UI
- extend the purchase card to display net, VAT, and gross totals while keeping currency formatting consistent
- add a Jest test that covers the tax breakdown helper with mock price data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54327be0c832dbed8140525314ff3