### PR TITLE
Refactor tax breakdown helper into shared module

### DIFF
--- a/__tests__/producerPurchases.test.ts
+++ b/__tests__/producerPurchases.test.ts
@@ -1,4 +1,4 @@
-import { calculateTaxBreakdown } from '@/app/dashboard/producer/purchases/page';
+import { calculateTaxBreakdown } from '@/lib/taxBreakdown';
 
 describe('calculateTaxBreakdown', () => {
   it('returns null when price is null', () => {

--- a/app/dashboard/producer/purchases/page.tsx
+++ b/app/dashboard/producer/purchases/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import AuthGuard from '@/components/AuthGuard';
 import { getSupabaseClient } from '@/lib/supabaseClient';
+import { calculateTaxBreakdown } from '@/lib/taxBreakdown';
 
 type OrderRow = {
   id: string;
@@ -22,22 +23,6 @@ const formatPrice = (priceCents: number | null) => {
     style: 'currency',
     currency: 'TRY',
   });
-};
-
-export const calculateTaxBreakdown = (priceCents: number | null) => {
-  if (priceCents == null) {
-    return null;
-  }
-
-  const netCents = priceCents;
-  const vatCents = Math.round(netCents * 0.2);
-  const grossCents = netCents + vatCents;
-
-  return {
-    netCents,
-    vatCents,
-    grossCents,
-  } as const;
 };
 
 const formatDateTime = (isoString: string) => {

--- a/components/dashboard/dashboard-shell.tsx
+++ b/components/dashboard/dashboard-shell.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 
 export type DashboardNavItem = {
   href: string;
@@ -73,9 +73,9 @@ export function DashboardShell({ children, navItems }: DashboardShellProps) {
     <section
       className="relative flex min-h-screen bg-[#faf3e0] text-[#0e5b4a]"
       style={{
-        ['--dashboard-accent' as '--dashboard-accent']: ACCENT,
-        ['--dashboard-nav-bg' as '--dashboard-nav-bg']: NAV_BG,
-      }}
+        '--dashboard-accent': ACCENT,
+        '--dashboard-nav-bg': NAV_BG,
+      } as CSSProperties}
     >
       {/* Desktop sidebar */}
       <aside

--- a/lib/taxBreakdown.ts
+++ b/lib/taxBreakdown.ts
@@ -1,0 +1,15 @@
+export const calculateTaxBreakdown = (priceCents: number | null) => {
+  if (priceCents == null) {
+    return null;
+  }
+
+  const netCents = priceCents;
+  const vatCents = Math.round(netCents * 0.2);
+  const grossCents = netCents + vatCents;
+
+  return {
+    netCents,
+    vatCents,
+    grossCents,
+  } as const;
+};


### PR DESCRIPTION
## Summary
- move the `calculateTaxBreakdown` helper into a dedicated shared module
- update the producer purchases page and its unit test to consume the shared helper
- fix dashboard shell styling types so the build completes cleanly

## Testing
- npm run build
- npm test -- --runInBand __tests__/producerPurchases.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68da3900edd0832db4c0774be63de567