### PR TITLE
Fix producer deadline handling and refresh public UX

### DIFF
--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -4,8 +4,8 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <section className="min-h-screen flex items-center justify-center bg-[#faf3e0] p-4">
-      <div className="bg-white rounded-xl shadow-lg p-8 w-full max-w-md border-l-4 border-[#f9c74f]">
+    <section className="flex min-h-screen h-[100dvh] w-full items-center justify-center overflow-hidden bg-[#faf3e0] px-4 py-10">
+      <div className="w-full max-w-lg space-y-6 rounded-2xl border border-[#f5d9a6] bg-white/95 p-10 shadow-xl">
         {children}
       </div>
     </section>

--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -62,14 +62,17 @@ export default function ProducerApplicationsPage() {
   const [totalCount, setTotalCount] = useState(0);
   const [idFilterType, setIdFilterType] = useState<IdFilter>('all');
   const [idFilterValue, setIdFilterValue] = useState('');
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const supabase = useMemo(getSupabaseClient, []);
 
   const fetchApplications = useCallback(async () => {
     setLoading(true);
+    setFetchError(null);
 
     if (!supabase) {
       setApplications([]);
       setTotalCount(0);
+      setFetchError('Supabase istemcisi kullanılamıyor.');
       setLoading(false);
       return;
     }
@@ -81,6 +84,7 @@ export default function ProducerApplicationsPage() {
     if (!user) {
       setApplications([]);
       setTotalCount(0);
+      setFetchError('Oturum doğrulanamadı. Lütfen tekrar giriş yapın.');
       setLoading(false);
       return;
     }
@@ -137,6 +141,7 @@ export default function ProducerApplicationsPage() {
       console.error('Başvurular alınamadı:', error.message);
       setApplications([]);
       setTotalCount(0);
+      setFetchError('Başvurular yüklenemedi. Lütfen daha sonra tekrar deneyin.');
     } else {
       const takeFirst = <T,>(value: MaybeArray<T>): T | null => {
         if (Array.isArray(value)) {
@@ -233,6 +238,7 @@ export default function ProducerApplicationsPage() {
           return;
         }
       }
+      setFetchError(null);
     }
 
     setLoading(false);
@@ -425,12 +431,18 @@ export default function ProducerApplicationsPage() {
                 className="rounded border border-[#d4c2a8] px-2 py-1 text-sm"
               />
             </label>
-          </div>
         </div>
+      </div>
 
-        {loading ? (
-          <p className="text-sm text-[#a38d6d]">Yükleniyor...</p>
-        ) : applications.length === 0 ? (
+      {fetchError ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {fetchError}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <p className="text-sm text-[#a38d6d]">Yükleniyor...</p>
+      ) : applications.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-[#e0d2bf] bg-white p-10 text-center text-[#7a5c36]">
             <span className="text-4xl" role="img" aria-hidden>
               📭

--- a/app/dashboard/producer/listings/new/page.tsx
+++ b/app/dashboard/producer/listings/new/page.tsx
@@ -63,7 +63,7 @@ export default function NewProducerListingPage() {
     let deadlineValue: string | null = null;
 
     if (deadline) {
-      const parsedDeadline = new Date(deadline);
+      const parsedDeadline = new Date(`${deadline}T23:59:59`);
 
       if (Number.isNaN(parsedDeadline.getTime())) {
         alert('Lütfen geçerli bir son teslim tarihi girin.');
@@ -79,7 +79,7 @@ export default function NewProducerListingPage() {
         return;
       }
 
-      deadlineValue = parsedDeadline.toISOString();
+      deadlineValue = deadline;
     }
 
     const { error } = await supabase.from('producer_listings').insert([
@@ -155,7 +155,7 @@ export default function NewProducerListingPage() {
               Son Teslim Tarihi
             </label>
             <input
-              type="datetime-local"
+              type="date"
               className="w-full p-2 border rounded-lg"
               value={deadline}
               onChange={(event) => setDeadline(event.target.value)}

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -16,16 +16,29 @@ const dateFormatter = new Intl.DateTimeFormat('tr-TR', {
   dateStyle: 'medium',
 });
 
-const dateTimeFormatter = new Intl.DateTimeFormat('tr-TR', {
-  dateStyle: 'medium',
-  timeStyle: 'short',
-});
-
 const budgetLabel = (budgetCents: number | null | undefined) => {
   if (typeof budgetCents === 'number') {
     return currencyFormatter.format(budgetCents / 100);
   }
   return 'Belirtilmemiş';
+};
+
+const formatDeadline = (deadline: string | null | undefined) => {
+  if (!deadline) {
+    return '—';
+  }
+
+  const normalized = deadline.includes('T')
+    ? deadline
+    : `${deadline}T00:00:00`;
+
+  const parsed = new Date(normalized);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return '—';
+  }
+
+  return dateFormatter.format(parsed);
 };
 
 export default function ProducerListingsPage() {
@@ -140,12 +153,7 @@ export default function ProducerListingsPage() {
                     <span>
                       Oluşturuldu: {dateFormatter.format(new Date(listing.created_at))}
                     </span>
-                    <span>
-                      Son teslim:{' '}
-                      {listing.deadline
-                        ? dateTimeFormatter.format(new Date(listing.deadline))
-                        : 'Belirtilmemiş'}
-                    </span>
+                    <span>Son teslim: {formatDeadline(listing.deadline)}</span>
                     {listing.source === 'requests' ? (
                       <span className="text-xs uppercase tracking-wide text-[#a38d6d]">
                         Eski Talep

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,15 +15,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="tr">
-      <body className="flex min-h-screen flex-col bg-[#faf3e0] text-[#7a5c36] font-sans">
+      <body className="flex min-h-screen flex-col overflow-x-hidden bg-[#faf3e0] text-[#7a5c36] font-sans">
         <TabTitleHandler />
 
         <AppHeader />
 
-        <main className="flex-1 max-w-7xl mx-auto px-4 py-10">{children}</main>
+        <main className="flex-1 w-full max-w-7xl mx-auto px-4 py-10">{children}</main>
 
         <footer
-          className="bg-forest text-brand py-4"
+          className="w-full bg-forest text-brand py-4"
           data-test-id="app-footer"
         >
           <div className="mx-auto max-w-7xl px-4 text-center text-sm opacity-80">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,28 +3,73 @@
 import { Typewriter } from 'react-simple-typewriter';
 
 export default function HomePage() {
+  const infoSections = [
+    {
+      id: 'about',
+      eyebrow: 'Hakkımızda',
+      title: 'ducktylo senaristler ile yapımcıları aynı masada buluşturur',
+      description:
+        'Türkiye ve bölge pazarındaki yaratıcı ekipleri tek bir üretim ağı altında topluyoruz. Projenizi sergileyin, doğru partnerleri bulun ve tüm süreci tek panelden yönetin.',
+      items: [
+        {
+          title: 'Seçici topluluk',
+          body: 'Onaylı senaristler ve projeye hazır yapımcılarla, spam içermeyen ve güvenli bir ortamda eşleşirsiniz.',
+        },
+        {
+          title: 'Güvenli paylaşım',
+          body: 'Senaryolarınız versiyon kontrollü olarak saklanır; erişim izinlerini tek tıkla yönetirsiniz.',
+        },
+        {
+          title: 'Gerçek destek',
+          body: 'Etkinlikler, mentorluk ve sektör profesyonellerinden alınan geri bildirimler tek platformda.',
+        },
+      ],
+    },
+    {
+      id: 'how-it-works',
+      eyebrow: 'Nasıl Çalışır',
+      title: 'Üç adımda üretim partnerinizi bulun',
+      description:
+        'ducktylo, fikirden prodüksiyona uzanan süreci sadeleştirir. Rolünüze göre akıllı paneller, filtremeler ve bildirimlerle her adımı kontrol edersiniz.',
+      items: [
+        {
+          title: '1. Profilini güçlendir',
+          body: 'Senaristler vitrinlerini oluşturur, yapımcılar ihtiyaçlarını paylaşır. Tüm bilgiler tek panelde tutulur.',
+        },
+        {
+          title: '2. Filtrele & keşfet',
+          body: 'Tür, bütçe, uzunluk ve teslim tarihine göre eşleşen projeleri saniyeler içinde bulun.',
+        },
+        {
+          title: '3. Bağlan & yürüt',
+          body: 'İlgi bildirimi gönderin, mesajlaşın ve dosya paylaşın. Tüm süreç Supabase destekli altyapımızla güvence altında.',
+        },
+      ],
+    },
+  ] as const;
+
   return (
-    <div className="space-y-16">
+    <div className="flex min-h-[calc(100vh-10rem)] flex-col gap-16 overflow-hidden">
       {/* Hero */}
-      <section className="text-center">
-        <h1 className="text-4xl font-bold mb-4">Senaryonuz Dünyaya Ulaşsın</h1>
+      <section className="relative isolate flex flex-col items-center gap-8 overflow-hidden rounded-3xl border border-[#e8dcc5] bg-white/70 px-6 py-16 text-center shadow-lg backdrop-blur-sm md:px-16">
+        <div className="absolute inset-x-20 -top-24 h-48 rounded-full bg-brand/10 blur-3xl" aria-hidden />
+        <h1 className="text-4xl font-bold text-[#0e5b4a] md:text-5xl">
+          Senaryonuz doğru yapımcıyla dakikalar içinde buluşsun
+        </h1>
         <p
-          className="text-lg max-w-2xl mx-auto font-sans text-[#7a5c36] overflow-hidden"
+          className="max-w-3xl text-lg leading-relaxed text-[#4a3d2f]"
           style={{
-            minHeight: '4rem', // minimum 2 satır yüksekliği
-            maxHeight: '4rem', // maksimum 2 satır yüksekliği
+            minHeight: '4rem',
+            maxHeight: '4rem',
           }}
         >
           <Typewriter
             words={[
-              'ducktylo, senaristlerle yapımcıları bir araya getiren yenilikçi bir platformdur.',
-              'Burada senaryonuz doğru kişilere ulaşır ve projeleriniz hayat bulur.',
-              'ducktylo, senaryonuzun güvenli bir şekilde depolanmasını sağlar.',
-              'senarist-ducktylo-yapımcı.',
-              'burayı istediğimiz kadar uzatabiliyor muyuz acaba?',
-              'bursada dehşet',
+              'ducktylo, senaristlerle yapımcıları aynı çalışma alanında buluşturur.',
+              'Filtrelenebilir ilanlar, güvenli paylaşım ve anlık bildirimlerle süreç hızlanır.',
+              'İster ilk senaryonuzu yükleyin ister yeni projeler arayan bir yapımcı olun.',
             ]}
-            loop={true}
+            loop
             typeSpeed={60}
             deleteSpeed={20}
             delaySpeed={600}
@@ -32,7 +77,7 @@ export default function HomePage() {
           <span className="blinking-cursor">|</span>
         </p>
 
-        <div className="mt-8 flex justify-center gap-4 flex-wrap">
+        <div className="flex flex-wrap justify-center gap-4">
           <a href="/auth/sign-up-writer" className="btn btn-primary">
             Senarist Olarak Katıl
           </a>
@@ -46,28 +91,72 @@ export default function HomePage() {
       </section>
 
       {/* Özellik Kartları */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-6 text-center">
-          🚀 Özellikler
+      <section className="rounded-3xl border border-[#e8dcc5] bg-white/60 px-6 py-12 shadow-sm md:px-12">
+        <h2 className="mb-8 text-center text-2xl font-semibold text-[#0e5b4a]">
+          🚀 Öne Çıkan Özellikler
         </h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          <div className="card">
-            <h3 className="text-lg font-semibold mb-2">Senaryo Yükleme</h3>
-            <p>
-              Senaryolarınızı yükleyin, fiyatlandırın, yayınlayın. Her şey
-              kontrolünüzde.
+        <div className="grid gap-6 md:grid-cols-3">
+          <div className="card h-full border-none bg-white/90 shadow-md">
+            <h3 className="mb-3 text-lg font-semibold text-[#0e5b4a]">
+              Senaryo Vitrini
+            </h3>
+            <p className="text-sm text-[#4a3d2f]">
+              Senaryolarınızı yükleyin, fiyatlandırın ve panelinizden performansı takip edin. Tüm versiyonlar güvenle saklanır.
             </p>
           </div>
-          <div className="card">
-            <h3 className="text-lg font-semibold mb-2">Yapımcı Filtrelemesi</h3>
-            <p>Yapımcılar tür, süre ve bütçeye göre senaryolara ulaşır.</p>
+          <div className="card h-full border-none bg-white/90 shadow-md">
+            <h3 className="mb-3 text-lg font-semibold text-[#0e5b4a]">
+              Akıllı Filtreler
+            </h3>
+            <p className="text-sm text-[#4a3d2f]">
+              Yapımcılar tür, süre, bütçe ve son teslim tarihine göre eşleşen senaryolara saniyeler içinde ulaşır.
+            </p>
           </div>
-          <div className="card">
-            <h3 className="text-lg font-semibold mb-2">Güvenli Ödeme</h3>
-            <p>Komisyon sistemiyle korunan adil ödeme altyapısı.</p>
+          <div className="card h-full border-none bg-white/90 shadow-md">
+            <h3 className="mb-3 text-lg font-semibold text-[#0e5b4a]">
+              Güvenli İş Akışı
+            </h3>
+            <p className="text-sm text-[#4a3d2f]">
+              İlgi bildirimi, mesajlaşma ve ödeme süreçleri tek platformda; tüm adımlar kayıt altında.
+            </p>
           </div>
         </div>
       </section>
+
+      {infoSections.map((section) => (
+        <section
+          key={section.id}
+          id={section.id}
+          className="grid gap-10 rounded-3xl border border-[#e8dcc5] bg-white/70 px-6 py-12 shadow-sm md:grid-cols-2 md:px-12"
+        >
+          <div className="space-y-4">
+            <span className="text-sm font-semibold uppercase tracking-[0.2em] text-[#a38d6d]">
+              {section.eyebrow}
+            </span>
+            <h2 className="text-3xl font-bold text-[#0e5b4a]">
+              {section.title}
+            </h2>
+            <p className="text-base leading-relaxed text-[#4a3d2f]">
+              {section.description}
+            </p>
+          </div>
+          <div className="space-y-5">
+            {section.items.map((item) => (
+              <div
+                key={item.title}
+                className="rounded-2xl border border-[#f1e6d7] bg-white/90 p-5 shadow-sm"
+              >
+                <h3 className="text-lg font-semibold text-[#0e5b4a]">
+                  {item.title}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-[#4a3d2f]">
+                  {item.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -88,7 +88,7 @@ export default function AppHeader() {
 
   return (
     <header
-      className="bg-forest text-brand py-4 shadow-md"
+      className="w-full bg-forest text-brand py-4 shadow-md"
       data-test-id="HEADER_NAV_V2"
     >
       <div className="mx-auto flex max-w-7xl items-center px-4">

--- a/components/dashboard/dashboard-shell.tsx
+++ b/components/dashboard/dashboard-shell.tsx
@@ -79,7 +79,7 @@ export function DashboardShell({ children, navItems }: DashboardShellProps) {
     >
       {/* Desktop sidebar */}
       <aside
-        className="hidden w-72 shrink-0 flex-col justify-between border-r border-white/10 bg-[var(--dashboard-nav-bg)] px-6 pb-8 pt-10 text-white md:flex"
+        className="hidden w-72 shrink-0 flex-col justify-between border-r border-white/10 bg-[var(--dashboard-nav-bg)] px-6 pb-8 pt-10 text-white md:sticky md:top-0 md:flex md:h-[100dvh] md:max-h-[100dvh] md:overflow-y-auto"
         aria-label="Panel gezinme"
       >
         <div className="space-y-10">

--- a/sql/migrations/mvp_patch.sql
+++ b/sql/migrations/mvp_patch.sql
@@ -301,6 +301,7 @@ select
   l.genre,
   l.budget_cents,
   l.created_at,
+  l.deadline,
   'producer_listings'::text as source
 from public.producer_listings l
 union all
@@ -315,5 +316,6 @@ select
     else round(r.budget)::integer
   end as budget_cents,
   r.created_at,
+  r.deadline::date,
   'requests'::text as source
 from public.requests r;

--- a/supabase/migrations/20240721000000_fix_deadline_and_view.sql
+++ b/supabase/migrations/20240721000000_fix_deadline_and_view.sql
@@ -1,0 +1,48 @@
+-- Ensure producer listings expose an optional deadline column for dashboards
+alter table if exists public.producer_listings
+  add column if not exists deadline date;
+
+-- Normalize existing deadline data to the date type if needed
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'producer_listings'
+      AND column_name = 'deadline'
+      AND data_type <> 'date'
+  ) THEN
+    ALTER TABLE public.producer_listings
+      ALTER COLUMN deadline TYPE date USING deadline::date;
+  END IF;
+END $$;
+
+-- Unified listings view consumed by both dashboards now exposes deadline safely
+create or replace view public.v_listings_unified as
+select
+  l.id,
+  l.owner_id,
+  l.title,
+  l.description,
+  l.genre,
+  l.budget_cents,
+  l.created_at,
+  l.deadline,
+  'producer_listings'::text as source
+from public.producer_listings l
+union all
+select
+  r.id,
+  coalesce(r.producer_id, r.user_id) as owner_id,
+  r.title,
+  r.description,
+  r.genre,
+  case
+    when r.budget is null then null
+    else round(r.budget)::integer
+  end as budget_cents,
+  r.created_at,
+  r.deadline::date,
+  'requests'::text as source
+from public.requests r;


### PR DESCRIPTION
## Summary
- add an idempotent migration to expose the producer_listings.deadline column as a date and refresh v_listings_unified with the new field
- wire the optional deadline through producer listing create/list pages, improve producer browse filters/reset UX, and surface friendly errors in applications
- align dashboard sidebar behaviour, marketing hero/About/How layout, and authentication container sizing to match the design system

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7e3a87b0832daa93c2cc8d662878