### PR TITLE
Add migration to rebuild unified listings view

### DIFF
--- a/supabase/migrations/20240722000000_update_v_listings_unified.sql
+++ b/supabase/migrations/20240722000000_update_v_listings_unified.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+DROP VIEW IF EXISTS public.v_listings_unified;
+
+CREATE VIEW public.v_listings_unified AS
+SELECT
+  l.id,
+  l.owner_id,
+  l.title,
+  l.description,
+  l.genre,
+  l.budget_cents::numeric AS budget,
+  l.created_at,
+  l.deadline,
+  'open'::text AS status,
+  'producer_listing'::text AS source
+FROM public.producer_listings l
+UNION ALL
+SELECT
+  r.id,
+  COALESCE(r.producer_id, r.user_id) AS owner_id,
+  r.title,
+  r.description,
+  r.genre,
+  r.budget,
+  r.created_at,
+  r.deadline,
+  'open'::text AS status,
+  'request'::text AS source
+FROM public.requests r;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration that drops and recreates `public.v_listings_unified` with the new shape, including budget as numeric and default open status

## Testing
- npx supabase db push *(fails: Cannot find project ref. Have you run supabase link?)*

------
https://chatgpt.com/codex/tasks/task_e_68de4d9a2814832daacd118b2cb7f589