### PR TITLE
Update producer listings view for unified listing data

### DIFF
--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { getSupabaseClient } from '@/lib/supabaseClient';
-import type { Listing } from '@/types/db';
+import type { VListingUnified } from '@/types/db';
 
 const currencyFormatter = new Intl.NumberFormat('tr-TR', {
   style: 'currency',
@@ -16,9 +16,9 @@ const dateFormatter = new Intl.DateTimeFormat('tr-TR', {
   dateStyle: 'medium',
 });
 
-const budgetLabel = (budgetCents: number | null | undefined) => {
-  if (typeof budgetCents === 'number') {
-    return currencyFormatter.format(budgetCents / 100);
+const budgetLabel = (budget: number | null | undefined) => {
+  if (typeof budget === 'number') {
+    return currencyFormatter.format(budget);
   }
   return 'Belirtilmemiş';
 };
@@ -27,23 +27,26 @@ const formatDeadline = (deadline: string | null | undefined) => {
   if (!deadline) {
     return '—';
   }
+  return deadline.slice(0, 10);
+};
 
-  const normalized = deadline.includes('T')
-    ? deadline
-    : `${deadline}T00:00:00`;
+const getListingBadge = (listing: VListingUnified) => {
+  const listingType = listing.status ?? listing.source;
 
-  const parsed = new Date(normalized);
-
-  if (Number.isNaN(parsed.getTime())) {
-    return '—';
+  if (listingType === 'request') {
+    return 'Talep';
   }
 
-  return dateFormatter.format(parsed);
+  if (listingType === 'producer_listing') {
+    return 'Yapımcı İlanı';
+  }
+
+  return null;
 };
 
 export default function ProducerListingsPage() {
   const router = useRouter();
-  const [listings, setListings] = useState<Listing[]>([]);
+  const [listings, setListings] = useState<VListingUnified[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const supabase = useMemo(getSupabaseClient, []);
@@ -80,7 +83,7 @@ export default function ProducerListingsPage() {
       const { data, error: listingsError } = await supabase
         .from('v_listings_unified')
         .select(
-          'id, owner_id, title, genre, description, budget_cents, created_at, deadline, source'
+          'id,owner_id,title,genre,description,budget,created_at,deadline,status,source'
         )
         .eq('owner_id', user.id)
         .order('created_at', { ascending: false });
@@ -88,7 +91,7 @@ export default function ProducerListingsPage() {
       if (listingsError) {
         setError(listingsError.message);
       } else {
-        setListings((data ?? []) as Listing[]);
+        setListings((data ?? []) as VListingUnified[]);
       }
 
       setLoading(false);
@@ -145,7 +148,7 @@ export default function ProducerListingsPage() {
                       {listing.title}
                     </h2>
                     <span className="text-sm font-medium text-[#ffaa06]">
-                      {budgetLabel(listing.budget_cents)}
+                      {budgetLabel(listing.budget)}
                     </span>
                   </div>
                   <div className="flex flex-wrap items-center gap-4 text-sm text-[#7a5c36]">
@@ -154,9 +157,9 @@ export default function ProducerListingsPage() {
                       Oluşturuldu: {dateFormatter.format(new Date(listing.created_at))}
                     </span>
                     <span>Son teslim: {formatDeadline(listing.deadline)}</span>
-                    {listing.source === 'requests' ? (
+                    {getListingBadge(listing) ? (
                       <span className="text-xs uppercase tracking-wide text-[#a38d6d]">
-                        Eski Talep
+                        {getListingBadge(listing)}
                       </span>
                     ) : null}
                   </div>

--- a/types/db.ts
+++ b/types/db.ts
@@ -37,6 +37,21 @@ export interface Listing {
   source: ListingSource;
 }
 
+export type VListingUnifiedStatus = 'producer_listing' | 'request';
+
+export interface VListingUnified {
+  id: string;
+  owner_id: string;
+  title: string;
+  genre: string | null;
+  description: string | null;
+  budget: number | null;
+  created_at: string;
+  deadline: string | null;
+  status: VListingUnifiedStatus | null;
+  source: VListingUnifiedStatus | null;
+}
+
 export interface ProducerListing {
   id: string;
   owner_id: string;


### PR DESCRIPTION
## Summary
- update the producer listings page to query the unified view columns and render the new budget/deadline formats
- add display handling for the new producer listing/request status values and use the unified listing type
- introduce the VListingUnified type in the shared database typings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4d9c255c832daa7515118732bc20