### PR TITLE
Update listing view types to VListingUnified

### DIFF
--- a/__tests__/producer-applications.test.tsx
+++ b/__tests__/producer-applications.test.tsx
@@ -77,7 +77,7 @@ describe('ProducerApplicationsPage', () => {
             price_cents: 150000,
           },
           writer: { id: 'writer-1', email: 'writer@example.com' },
-          listing: { id: 'listing-1', title: 'Test Listing', source: 'requests' },
+          listing: { id: 'listing-1', title: 'Test Listing', source: 'request' },
           conversations: [],
         },
       ],

--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { ensureConversationWithParticipants } from '@/lib/conversations';
 import { getSupabaseClient } from '@/lib/supabaseClient';
-import type { Listing } from '@/types/db';
+import type { VListingUnified } from '@/types/db';
 
 type ApplicationRow = {
   id: string;
@@ -49,7 +49,7 @@ const budgetLabel = (budgetCents: number | null | undefined) => {
 export default function ProducerListingDetailPage() {
   const { id: listingId } = useParams<{ id: string }>();
   const router = useRouter();
-  const [listing, setListing] = useState<Listing | null>(null);
+  const [listing, setListing] = useState<VListingUnified | null>(null);
   const [applications, setApplications] = useState<ApplicationRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -115,7 +115,7 @@ export default function ProducerListingDetailPage() {
 
         if (!isMounted) return;
 
-        setListing(listingData as Listing);
+        setListing(listingData as VListingUnified);
 
         const { data: applicationRows, error: applicationsError } = await supabase
           .from('applications')

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { getSupabaseClient } from '@/lib/supabaseClient';
-import type { Listing } from '@/types/db';
+import type { VListingUnified } from '@/types/db';
 
 const currencyFormatter = new Intl.NumberFormat('tr-TR', {
   style: 'currency',
@@ -43,7 +43,7 @@ const formatDeadline = (deadline: string | null | undefined) => {
 
 export default function ProducerListingsPage() {
   const router = useRouter();
-  const [listings, setListings] = useState<Listing[]>([]);
+  const [listings, setListings] = useState<VListingUnified[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const supabase = useMemo(getSupabaseClient, []);
@@ -88,7 +88,7 @@ export default function ProducerListingsPage() {
       if (listingsError) {
         setError(listingsError.message);
       } else {
-        setListings((data ?? []) as Listing[]);
+        setListings((data ?? []) as VListingUnified[]);
       }
 
       setLoading(false);
@@ -154,7 +154,7 @@ export default function ProducerListingsPage() {
                       Oluşturuldu: {dateFormatter.format(new Date(listing.created_at))}
                     </span>
                     <span>Son teslim: {formatDeadline(listing.deadline)}</span>
-                    {listing.source === 'requests' ? (
+                    {listing.source === 'request' ? (
                       <span className="text-xs uppercase tracking-wide text-[#a38d6d]">
                         Eski Talep
                       </span>

--- a/app/dashboard/writer/listings/[id]/page.tsx
+++ b/app/dashboard/writer/listings/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { getSupabaseClient } from '@/lib/supabaseClient';
-import type { Listing } from '@/types/db';
+import type { VListingUnified } from '@/types/db';
 
 type WriterScriptOption = {
   id: string;
@@ -34,7 +34,7 @@ const budgetLabel = (budgetCents: number | null | undefined) => {
 export default function ListingDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
-  const [listing, setListing] = useState<Listing | null>(null);
+  const [listing, setListing] = useState<VListingUnified | null>(null);
   const [loading, setLoading] = useState(true);
   const [scripts, setScripts] = useState<WriterScriptOption[]>([]);
   const [selectedScript, setSelectedScript] = useState('');
@@ -43,7 +43,7 @@ export default function ListingDetailPage() {
   const [submitting, setSubmitting] = useState(false);
   const previousScriptIdsRef = useRef<Set<string>>(new Set());
   const previousMatchingCountRef = useRef(0);
-  const listingRef = useRef<Listing | null>(null);
+  const listingRef = useRef<VListingUnified | null>(null);
   const supabase = useMemo(getSupabaseClient, []);
 
   const normalizeGenre = (genre: string | null | undefined) =>
@@ -92,7 +92,7 @@ export default function ListingDetailPage() {
       if (error) {
         console.error(error.message);
       }
-      setListing((data as Listing | null) ?? null);
+      setListing((data as VListingUnified | null) ?? null);
       setLoading(false);
     };
     fetchListing();
@@ -360,7 +360,7 @@ export default function ListingDetailPage() {
       owner_id: listing?.owner_id ?? null,
     };
 
-    if (listing?.source === 'requests') {
+    if (listing?.source === 'request') {
       (payload as any).request_id = id;
       (payload as any).producer_id = listing?.owner_id ?? null;
     } else {

--- a/app/dashboard/writer/listings/page.tsx
+++ b/app/dashboard/writer/listings/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { getSupabaseClient } from '@/lib/supabaseClient';
-import type { Listing } from '@/types/db';
+import type { VListingUnified } from '@/types/db';
 
 const currency = new Intl.NumberFormat('tr-TR', {
   style: 'currency',
@@ -19,7 +19,7 @@ const budgetLabel = (budgetCents: number | null) => {
 };
 
 export default function BrowseListingsPage() {
-  const [listings, setListings] = useState<Listing[]>([]);
+  const [listings, setListings] = useState<VListingUnified[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,7 +46,7 @@ export default function BrowseListingsPage() {
         setError(error.message);
         setListings([]);
       } else {
-        setListings((data as Listing[]) || []);
+        setListings((data as VListingUnified[]) || []);
       }
       setLoading(false);
     };

--- a/types/db.ts
+++ b/types/db.ts
@@ -23,9 +23,9 @@ export interface Script {
   created_at: string; // ISO
 }
 
-export type ListingSource = 'producer_listings' | 'requests';
+export type ListingSource = 'producer_listing' | 'request';
 
-export interface Listing {
+export type VListingUnified = {
   id: string;
   owner_id: string | null;
   title: string;
@@ -33,9 +33,9 @@ export interface Listing {
   genre: string;
   budget_cents: number | null;
   created_at: string;
-  deadline?: string | null;
+  deadline: string | null;
   source: ListingSource;
-}
+};
 
 export interface ProducerListing {
   id: string;


### PR DESCRIPTION
## Summary
- add the VListingUnified type and new listing source literals in the shared db types
- switch listing pages to the new VListingUnified type and updated source comparisons
- align producer applications test data with the new request source string

## Testing
- npm test -- --runTestsByPath __tests__/producer-applications.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de4d9de334832d80922be807b1520e