### PR TITLE
refactor: adopt budget field for listings

### DIFF
--- a/__tests__/producer-listing-detail.test.tsx
+++ b/__tests__/producer-listing-detail.test.tsx
@@ -50,7 +50,7 @@ const baseListing = {
   title: 'Test Listing',
   description: 'Detaylı açıklama',
   genre: 'Drama',
-  budget_cents: 150000,
+  budget: 150000,
   created_at: '2024-01-01T00:00:00.000Z',
   source: null,
 };

--- a/app/dashboard/producer/listings/[id]/page.tsx
+++ b/app/dashboard/producer/listings/[id]/page.tsx
@@ -39,9 +39,9 @@ const dateTimeFormatter = new Intl.DateTimeFormat('tr-TR', {
   timeStyle: 'short',
 });
 
-const budgetLabel = (budgetCents: number | null | undefined) => {
-  if (typeof budgetCents === 'number') {
-    return currencyFormatter.format(budgetCents / 100);
+const budgetLabel = (budget: number | null | undefined) => {
+  if (typeof budget === 'number') {
+    return currencyFormatter.format(budget);
   }
   return 'Belirtilmemiş';
 };
@@ -96,7 +96,7 @@ export default function ProducerListingDetailPage() {
         const { data: listingData, error: listingError } = await supabase
           .from('v_listings_unified')
           .select(
-            'id, owner_id, title, description, genre, budget_cents, created_at, deadline, source'
+            'id, owner_id, title, description, genre, budget, created_at, deadline, source'
           )
           .eq('id', listingId)
           .maybeSingle();
@@ -422,7 +422,7 @@ export default function ProducerListingDetailPage() {
             <div className="space-y-3">
               <h1 className="text-2xl font-bold text-[#0e5b4a]">{listing.title}</h1>
               <p className="text-sm text-[#7a5c36]">
-                Tür: {listing.genre} · Bütçe: {budgetLabel(listing.budget_cents)}
+                Tür: {listing.genre} · Bütçe: {budgetLabel(listing.budget)}
               </p>
               <p className="text-xs text-[#a38d6d]">
                 Oluşturulma tarihi: {dateFormatter.format(new Date(listing.created_at))}

--- a/app/dashboard/producer/messages/page.tsx
+++ b/app/dashboard/producer/messages/page.tsx
@@ -166,7 +166,7 @@ export default function ProducerMessagesPage() {
                   title,
                   owner_id,
                   genre,
-                  budget_cents,
+                  budget,
                   created_at,
                   source
                 ),

--- a/app/dashboard/writer/listings/[id]/page.tsx
+++ b/app/dashboard/writer/listings/[id]/page.tsx
@@ -24,9 +24,9 @@ const currency = new Intl.NumberFormat('tr-TR', {
   maximumFractionDigits: 2,
 });
 
-const budgetLabel = (budgetCents: number | null | undefined) => {
-  if (typeof budgetCents === 'number') {
-    return currency.format(budgetCents / 100);
+const budgetLabel = (budget: number | null | undefined) => {
+  if (typeof budget === 'number') {
+    return currency.format(budget);
   }
   return 'Belirtilmemiş';
 };
@@ -85,7 +85,7 @@ export default function ListingDetailPage() {
       const { data, error } = await supabase
         .from('v_listings_unified')
         .select(
-          'id, owner_id, title, genre, description, budget_cents, created_at, source'
+          'id, owner_id, title, genre, description, budget, created_at, source'
         )
         .eq('id', id)
         .maybeSingle();
@@ -406,7 +406,7 @@ export default function ListingDetailPage() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">🎬 {listing.title}</h1>
       <p className="text-sm text-[#7a5c36]">
-        Tür: {listing.genre} · Bütçe: {budgetLabel(listing.budget_cents)}
+        Tür: {listing.genre} · Bütçe: {budgetLabel(listing.budget)}
       </p>
       <div className="bg-white rounded-xl shadow p-6 border-l-4 border-[#f9c74f] space-y-4">
         <p className="text-[#4a3d2f]">

--- a/app/dashboard/writer/listings/page.tsx
+++ b/app/dashboard/writer/listings/page.tsx
@@ -11,9 +11,9 @@ const currency = new Intl.NumberFormat('tr-TR', {
   maximumFractionDigits: 2,
 });
 
-const budgetLabel = (budgetCents: number | null) => {
-  if (typeof budgetCents === 'number') {
-    return currency.format(budgetCents / 100);
+const budgetLabel = (budget: number | null) => {
+  if (typeof budget === 'number') {
+    return currency.format(budget);
   }
   return 'Belirtilmemiş';
 };
@@ -40,7 +40,7 @@ export default function BrowseListingsPage() {
       setError(null);
       const { data, error } = await supabase
         .from('v_listings_unified')
-        .select('id, owner_id, title, genre, description, budget_cents, created_at, source')
+        .select('id, owner_id, title, genre, description, budget, created_at, source')
         .order('created_at', { ascending: false });
       if (error) {
         setError(error.message);
@@ -122,7 +122,7 @@ export default function BrowseListingsPage() {
             <div className="card space-y-2" key={l.id}>
               <h2 className="text-lg font-semibold">{l.title}</h2>
               <p className="text-sm text-[#7a5c36]">
-                Tür: {l.genre} · Bütçe: {budgetLabel(l.budget_cents ?? null)}
+                Tür: {l.genre} · Bütçe: {budgetLabel(l.budget ?? null)}
               </p>
               <p className="text-sm text-[#4a3d2f]">{excerpt(l.description)}</p>
               <div className="mt-2">

--- a/app/dashboard/writer/messages/page.tsx
+++ b/app/dashboard/writer/messages/page.tsx
@@ -182,7 +182,7 @@ export default function WriterMessagesPage() {
                   id,
                   title,
                   genre,
-                  budget_cents,
+                  budget,
                   owner_id,
                   source,
                   created_at

--- a/app/dashboard/writer/page.tsx
+++ b/app/dashboard/writer/page.tsx
@@ -29,7 +29,7 @@ type ListingRow = {
   id: string;
   title: string;
   genre: string | null;
-  budget_cents: number | null;
+  budget: number | null;
   created_at: string | null;
   source: string | null;
 };
@@ -187,7 +187,7 @@ export default function WriterDashboardPage() {
         if (listingIds.length > 0) {
           const { data: listingsData, error: listingsError } = await supabase
             .from('v_listings_unified')
-            .select('id,title,genre,budget_cents,created_at,source')
+            .select('id,title,genre,budget,created_at,source')
             .in('id', listingIds);
 
           if (listingsError) {

--- a/scripts/seed-mvp.ts
+++ b/scripts/seed-mvp.ts
@@ -25,7 +25,7 @@ type ListingSeed = {
   title: string;
   genre: string;
   description: string;
-  budget_cents: number;
+  budget: number;
 };
 
 const SUPABASE_URL =
@@ -455,7 +455,7 @@ async function main() {
     genre: 'Dram',
     description:
       'Uluslararası festivallerde yarışabilecek, güçlü kadın karakterli bir uzun metraj projesi arıyoruz. Sahil kasabası atmosferi ve dönüşüm hikayesi tercih sebebidir.',
-    budget_cents: 750000,
+    budget: 750000,
   };
 
   const acceptedListing = await ensureListing(adminClient, producer.id, acceptedListingSeed);
@@ -500,7 +500,7 @@ async function main() {
     genre: 'Belgesel',
     description:
       'Anadolu’daki arkeolojik keşifler üzerine 45-60 dakikalık bir belgesel için ortak yazar arıyoruz. Hazır senaryo önerilerine açığız.',
-    budget_cents: 520000,
+    budget: 520000,
   };
 
   await ensureListing(adminClient, producer.id, openListingSeed);

--- a/types/db.ts
+++ b/types/db.ts
@@ -25,31 +25,19 @@ export interface Script {
 
 export type ListingSource = 'producer_listing' | 'request';
 
-export type VListingUnified = {
+export type VListingUnifiedStatus = 'open' | 'closed' | 'draft' | string;
+
+export interface VListingUnified {
   id: string;
   owner_id: string | null;
   title: string;
   description: string | null;
-  genre: string;
-  budget_cents: number | null;
-  created_at: string;
-  deadline: string | null;
-  source: ListingSource;
-};
-
-export type VListingUnifiedStatus = 'producer_listing' | 'request';
-
-export interface VListingUnified {
-  id: string;
-  owner_id: string;
-  title: string;
   genre: string | null;
-  description: string | null;
   budget: number | null;
   created_at: string;
   deadline: string | null;
   status: VListingUnifiedStatus | null;
-  source: VListingUnifiedStatus | null;
+  source: ListingSource | null;
 }
 
 export interface ProducerListing {
@@ -58,7 +46,7 @@ export interface ProducerListing {
   title: string;
   description: string;
   genre: string;
-  budget_cents: number;
+  budget: number;
   created_at: string;
   deadline?: string | null;
 }


### PR DESCRIPTION
## Summary
- update writer and producer dashboard queries to read the `budget` field and format it as Turkish Lira directly
- consolidate the `VListingUnified` typings around the new `budget` property and refresh related seeds and tests

## Testing
- npm test -- __tests__/producer-listing-detail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de631f26b4832daab8dda63bddd8ac