### PR TITLE
Add floating back-to-top button

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import TabTitleHandler from '../components/TabTitleHandler';
 
 import AppHeader from '@/components/AppHeader';
+import BackToTop from '@/components/BackToTop';
 
 export const metadata = {
   title: 'ducktylo | Senaristler ve Yapımcılar için ortak nokta!',
@@ -21,6 +22,8 @@ export default function RootLayout({
         <AppHeader />
 
         <main className="flex-1 w-full max-w-7xl mx-auto px-4 py-10">{children}</main>
+
+        <BackToTop />
 
         <footer
           className="w-full bg-forest text-brand py-4"

--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function BackToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="Yukarı dön"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      className="fixed bottom-6 right-6 rounded-full bg-white/90 shadow-lg shadow-black/10 ring-1 ring-black/5 transition hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#a38d6d]"
+    >
+      <span className="block px-4 py-3 text-sm font-medium text-[#5b4632]">↑</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side BackToTop component that shows after scrolling and smooth scrolls to the top
- include the control in the root layout so it appears across the site

## Testing
- npm run dev (manually verified back-to-top button visibility, click, and focus behaviour in browser)


------
https://chatgpt.com/codex/tasks/task_e_68de84bf2070832db61f3a1819831a0b