### PR TITLE
Use Supabase RPCs for application decision flows

### DIFF
--- a/__tests__/producer-applications.test.tsx
+++ b/__tests__/producer-applications.test.tsx
@@ -28,10 +28,6 @@ jest.mock('@/lib/supabaseClient', () => ({
   getSupabaseClient: mockGetSupabaseClient,
 }));
 
-jest.mock('@/lib/conversations', () => ({
-  ensureConversationWithParticipants: jest.fn(),
-}));
-
 type QueryResponse = {
   data: Array<{
     id: string;

--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
-import { ensureConversationWithParticipants } from '@/lib/conversations';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 
 type ApplicationRow = {
@@ -51,18 +50,26 @@ type SupabaseApplicationRow = {
 type IdFilter = 'all' | 'listing' | 'producer_listing' | 'request';
 type Decision = 'accepted' | 'rejected' | 'on_hold' | 'purchased';
 
+type DecisionFeedback = {
+  type: 'success' | 'warning' | 'error';
+  message: string;
+};
+
 const PAGE_SIZE = 10;
 
 export default function ProducerApplicationsPage() {
   const router = useRouter();
   const [applications, setApplications] = useState<ApplicationRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
   const [idFilterType, setIdFilterType] = useState<IdFilter>('all');
   const [idFilterValue, setIdFilterValue] = useState('');
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [decisionLoadingId, setDecisionLoadingId] = useState<string | null>(null);
+  const [decisionFeedback, setDecisionFeedback] = useState<DecisionFeedback | null>(
+    null
+  );
   const supabase = useMemo(getSupabaseClient, []);
 
   const fetchApplications = useCallback(async () => {
@@ -88,8 +95,6 @@ export default function ProducerApplicationsPage() {
       setLoading(false);
       return;
     }
-
-    setCurrentUserId(user.id);
 
     const rangeStart = (currentPage - 1) * PAGE_SIZE;
     const rangeEnd = rangeStart + PAGE_SIZE - 1;
@@ -265,58 +270,62 @@ export default function ProducerApplicationsPage() {
 
   const handleDecision = async (applicationId: string, decision: Decision) => {
     if (!supabase) {
-      alert('Supabase istemcisi kullanılamıyor.');
+      const message = 'Supabase istemcisi kullanılamıyor.';
+      setDecisionFeedback({ type: 'error', message });
+      alert(message);
       return;
     }
 
-    const { error: updateError } = await supabase
-      .from('applications')
-      .update({ status: decision })
-      .eq('id', applicationId);
+    setDecisionLoadingId(applicationId);
+    setDecisionFeedback(null);
+
+    const { data: updatedApplication, error: updateError } = await supabase.rpc(
+      'mark_application_status',
+      {
+        p_application_id: applicationId,
+        p_status: decision,
+      }
+    );
 
     if (updateError) {
-      alert('❌ Güncelleme hatası: ' + updateError.message);
+      const message = `❌ Başvuru güncellenemedi: ${updateError.message}`;
+      setDecisionFeedback({ type: 'error', message });
+      alert(message);
+      setDecisionLoadingId(null);
       return;
     }
 
-    let conversationError: string | null = null;
+    const updatedStatus =
+      (updatedApplication as { status?: string } | null)?.status ?? decision;
 
+    setApplications((prev) =>
+      prev.map((application) =>
+        application.application_id === applicationId
+          ? { ...application, status: updatedStatus }
+          : application
+      )
+    );
+
+    let conversationError: string | null = null;
     let conversationId: string | null = null;
 
-    let actingUserId = currentUserId;
-
     if (decision === 'accepted') {
-      if (!actingUserId) {
-        const {
-          data: { user: freshUser },
-          error: authError,
-        } = await supabase.auth.getUser();
+      const { data: ensuredConversationId, error: ensureError } =
+        await supabase.rpc('ensure_conversation_for_application', {
+          p_application_id: applicationId,
+        });
 
-        if (authError) {
-          alert('❌ Oturum doğrulanamadı: ' + authError.message);
-          return;
-        }
-
-        if (!freshUser) {
-          alert('❌ Oturum doğrulanamadı. Lütfen tekrar giriş yapın.');
-          return;
-        }
-
-        actingUserId = freshUser.id;
-        setCurrentUserId(freshUser.id);
+      if (ensureError) {
+        console.error(ensureError);
+        conversationError = ensureError.message;
+      } else if (!ensuredConversationId) {
+        conversationError = 'Sohbet oluşturulamadı.';
+      } else {
+        conversationId = String(ensuredConversationId);
       }
     }
 
-    if (decision === 'accepted' && actingUserId) {
-      const { conversationId: ensuredConversationId, error } =
-        await ensureConversationWithParticipants(
-          supabase,
-          applicationId,
-          actingUserId
-        );
-      conversationError = error;
-      conversationId = ensuredConversationId;
-    }
+    setDecisionLoadingId(null);
 
     const successMessageMap: Record<Decision, string> = {
       accepted: '✅ Başvuru kabul edildi',
@@ -325,10 +334,21 @@ export default function ProducerApplicationsPage() {
       purchased: '🛒 Başvuru satın alma aşamasında işaretlendi',
     };
 
+    const feedbackTypeMap: Record<Decision, DecisionFeedback['type']> = {
+      accepted: 'success',
+      rejected: 'warning',
+      on_hold: 'warning',
+      purchased: 'success',
+    };
+
     if (conversationError) {
-      alert(`⚠️ Başvuru güncellendi ancak sohbet açılamadı: ${conversationError}`);
+      const message = `⚠️ Başvuru güncellendi ancak sohbet açılamadı: ${conversationError}`;
+      setDecisionFeedback({ type: 'warning', message });
+      alert(message);
     } else {
-      alert(successMessageMap[decision]);
+      const message = successMessageMap[decision];
+      setDecisionFeedback({ type: feedbackTypeMap[decision], message });
+      alert(message);
     }
 
     if (decision === 'accepted' && conversationId) {
@@ -340,7 +360,7 @@ export default function ProducerApplicationsPage() {
       }
     }
 
-    fetchApplications(); // Listeyi yenile veya yönlendirme başarısız olursa yedek
+    fetchApplications();
   };
 
   const getBadge = (status: string) => {
@@ -439,6 +459,19 @@ export default function ProducerApplicationsPage() {
           {fetchError}
         </div>
       ) : null}
+      {decisionFeedback ? (
+        <div
+          className={`rounded-lg border p-3 text-sm ${
+            decisionFeedback.type === 'success'
+              ? 'border-green-200 bg-green-50 text-green-800'
+              : decisionFeedback.type === 'warning'
+              ? 'border-yellow-200 bg-yellow-50 text-yellow-800'
+              : 'border-red-200 bg-red-50 text-red-700'
+          }`}
+        >
+          {decisionFeedback.message}
+        </div>
+      ) : null}
 
       {loading ? (
         <p className="text-sm text-[#a38d6d]">Yükleniyor...</p>
@@ -519,7 +552,8 @@ export default function ProducerApplicationsPage() {
                               onClick={() =>
                                 handleDecision(app.application_id, 'accepted')
                               }
-                              className="btn btn-primary"
+                              disabled={decisionLoadingId === app.application_id}
+                              className="btn btn-primary disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               ✅ Kabul Et
                             </button>
@@ -527,7 +561,8 @@ export default function ProducerApplicationsPage() {
                               onClick={() =>
                                 handleDecision(app.application_id, 'on_hold')
                               }
-                              className="btn btn-secondary"
+                              disabled={decisionLoadingId === app.application_id}
+                              className="btn btn-secondary disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               ⏳ Beklet
                             </button>
@@ -535,7 +570,8 @@ export default function ProducerApplicationsPage() {
                               onClick={() =>
                                 handleDecision(app.application_id, 'purchased')
                               }
-                              className="btn btn-secondary"
+                              disabled={decisionLoadingId === app.application_id}
+                              className="btn btn-secondary disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               🛒 Satın Al
                             </button>
@@ -543,7 +579,8 @@ export default function ProducerApplicationsPage() {
                               onClick={() =>
                                 handleDecision(app.application_id, 'rejected')
                               }
-                              className="btn btn-secondary"
+                              disabled={decisionLoadingId === app.application_id}
+                              className="btn btn-secondary disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               ❌ Reddet
                             </button>

--- a/lib/conversations.ts
+++ b/lib/conversations.ts
@@ -8,13 +8,12 @@ type ConversationResult = {
 export const ensureConversationWithParticipants = async (
   client: SupabaseClient,
   applicationId: string,
-  actingUserId?: string | null
+  _actingUserId?: string | null
 ): Promise<ConversationResult> => {
   const { data, error } = await client.rpc(
-    'ensure_conversation_with_participants',
+    'ensure_conversation_for_application',
     {
-      application_id: applicationId,
-      acting_user_id: actingUserId ?? null,
+      p_application_id: applicationId,
     }
   );
 

--- a/supabase/migrations/20251002_ducktylo_codex.sql
+++ b/supabase/migrations/20251002_ducktylo_codex.sql
@@ -1,0 +1,48 @@
+-- Centralized helpers for application status updates and conversation provisioning.
+create or replace function public.mark_application_status(
+  p_application_id uuid,
+  p_status text
+) returns public.applications
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_application public.applications%rowtype;
+begin
+  update public.applications
+  set status = p_status
+  where id = p_application_id
+  returning * into v_application;
+
+  if not found then
+    raise exception 'application % not found', p_application_id;
+  end if;
+
+  return v_application;
+end;
+$$;
+
+grant execute on function public.mark_application_status(uuid, text) to authenticated;
+
+-- Wrapper around ensure_conversation_with_participants for clarity in client RPC calls.
+create or replace function public.ensure_conversation_for_application(
+  p_application_id uuid
+) returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_conversation_id uuid;
+begin
+  v_conversation_id := public.ensure_conversation_with_participants(
+    p_application_id,
+    null
+  );
+
+  return v_conversation_id;
+end;
+$$;
+
+grant execute on function public.ensure_conversation_for_application(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add mark_application_status and ensure_conversation_for_application RPC helpers to centralize application status updates and conversation provisioning
- refactor producer decision flows to call the new RPCs, surface loading/error feedback, and invoke conversation provisioning when applications are accepted
- update the conversation helper and associated unit tests to align with the new RPC-based workflow

## Testing
- npm test -- __tests__/producer-listing-detail.test.tsx
- npm test -- __tests__/producer-applications.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de84bc3ad8832d81d976ad75e98db5