### PR TITLE
Update back to top button styling

### DIFF
--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -27,9 +27,9 @@ export default function BackToTop() {
       type="button"
       aria-label="Yukarı dön"
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-      className="fixed bottom-6 right-6 rounded-full bg-white/90 shadow-lg shadow-black/10 ring-1 ring-black/5 transition hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#a38d6d]"
+      className="fixed bottom-6 right-6 bg-[#0e5b4a] rounded-full shadow-lg p-3 hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#a38d6d]"
     >
-      <span className="block px-4 py-3 text-sm font-medium text-[#5b4632]">↑</span>
+      <span className="text-[#ffaa06] font-bold text-xl">↑</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- restyled the back-to-top button to use the new green background and orange icon while preserving focus-visible rings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8f033b7c832d99e6a37e8cfa229d