### PR TITLE
Add shared Supabase application row type

### DIFF
--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,41 @@
+export type SupabaseApplicationScriptMetadata =
+  | (Record<string, unknown> & {
+      id?: unknown;
+      title?: unknown;
+      length?: unknown;
+      price_cents?: unknown;
+      writer_email?: unknown;
+    })
+  | null;
+
+export interface SupabaseApplicationListing {
+  id: string | null;
+  title: string | null;
+  owner_id: string | null;
+  source: string | null;
+}
+
+export interface SupabaseApplicationWriter {
+  id: string | null;
+  email: string | null;
+}
+
+export interface SupabaseApplicationConversation {
+  id: string | null;
+}
+
+export interface SupabaseApplicationRow {
+  application_id: string | null;
+  status: string | null;
+  created_at: string | null;
+  listing_id: string | null;
+  producer_listing_id: string | null;
+  request_id: string | null;
+  owner_id: string | null;
+  producer_id: string | null;
+  script_id: string | null;
+  script_metadata: SupabaseApplicationScriptMetadata;
+  listing: SupabaseApplicationListing | null;
+  writer: SupabaseApplicationWriter | null;
+  conversations: SupabaseApplicationConversation[] | null;
+}


### PR DESCRIPTION
## Summary
- define `SupabaseApplicationRow` and related helpers to describe the `applications` query response
- refactor the producer applications page to consume the shared Supabase type instead of inline casts
- align the producer applications test with the shared Supabase type and query shape

## Testing
- npm test -- --runTestsByPath __tests__/producer-applications.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df963648bc832d90bc0d9e30520b19