### PR TITLE
Normalize listing source labels

### DIFF
--- a/app/dashboard/producer/applications/page.tsx
+++ b/app/dashboard/producer/applications/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
+import { getListingSourceLabel } from '@/lib/listings';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 import type {
   SupabaseApplicationRow,
@@ -123,7 +124,8 @@ export default function ProducerApplicationsPage() {
       setRawApplications([]);
       setFetchError(`Supabase hatası: ${error.message}`);
     } else {
-      const rows: SupabaseApplicationRow[] = Array.isArray(data) ? data : [];
+      const rawRows = Array.isArray(data) ? data : [];
+      const rows = rawRows as unknown as SupabaseApplicationRow[];
       setRawApplications(rows);
       setFetchError(null);
     }
@@ -257,8 +259,7 @@ export default function ProducerApplicationsPage() {
           ? String(scriptMetadata.writer_email)
           : null;
 
-      const listingSource =
-        item.listing?.source != null ? String(item.listing.source) : null;
+      const listingSource = getListingSourceLabel(item.listing?.source ?? null);
 
       const conversationId = Array.isArray(item.conversations)
         ? item.conversations.find((conversation) => conversation?.id)?.id

--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getListingSourceLabel, getListingStatusLabel } from '@/lib/listings';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 import Link from 'next/link';
 
@@ -577,6 +578,12 @@ export default function BrowseScriptsPage() {
           ) : (
             <div className="grid md:grid-cols-2 gap-6">
               {listings.map((listing) => {
+                const statusLabel =
+                  getListingStatusLabel(listing.status) ??
+                  (listing.status ? String(listing.status) : null);
+                const sourceLabel =
+                  getListingSourceLabel(listing.source) ??
+                  (listing.source ? String(listing.source) : null);
                 const formattedDeadline = listing.deadline
                   ? new Date(listing.deadline).toISOString().slice(0, 10)
                   : '—';
@@ -587,7 +594,7 @@ export default function BrowseScriptsPage() {
                         {listing.title || 'Başlıksız İlan'}
                       </h2>
                       <span className="text-xs font-medium uppercase tracking-wide text-[#7a5c36]">
-                        {listing.status || 'Durum Bilinmiyor'}
+                        {statusLabel || 'Durum Bilinmiyor'}
                       </span>
                     </div>
                     <p className="text-sm text-[#4a3d2f]">
@@ -616,7 +623,7 @@ export default function BrowseScriptsPage() {
                       </div>
                       <div>
                         <dt className="font-semibold">Kaynak</dt>
-                        <dd>{listing.source || 'Bilinmiyor'}</dd>
+                        <dd>{sourceLabel || 'Bilinmiyor'}</dd>
                       </div>
                     </dl>
                     <p className="text-xs text-gray-500">

--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import { getSupabaseClient } from '@/lib/supabaseClient';
 import type { VListingUnified } from '@/types/db';
+import { getListingSourceLabel, getListingStatusLabel } from '@/lib/listings';
 
 const currencyFormatter = new Intl.NumberFormat('tr-TR', {
   style: 'currency',
@@ -30,19 +31,8 @@ const formatDeadline = (deadline: string | null | undefined) => {
   return deadline.slice(0, 10);
 };
 
-const getListingBadge = (listing: VListingUnified) => {
-  const listingType = listing.status ?? listing.source;
-
-  if (listingType === 'request') {
-    return 'Talep';
-  }
-
-  if (listingType === 'producer_listing') {
-    return 'Yapımcı İlanı';
-  }
-
-  return null;
-};
+const getListingBadge = (listing: VListingUnified) =>
+  getListingSourceLabel(listing.source);
 
 export default function ProducerListingsPage() {
   const router = useRouter();
@@ -137,41 +127,54 @@ export default function ProducerListingsPage() {
           </div>
         ) : (
           <ul className="space-y-4">
-            {listings.map((listing) => (
-              <li key={listing.id}>
-                <Link
-                  href={`/dashboard/producer/listings/${listing.id}`}
-                  className="block p-4 bg-white border rounded-lg shadow-sm space-y-2 hover:border-[#0e5b4a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e5b4a]"
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <h2 className="text-lg font-semibold text-[#0e5b4a]">
-                      {listing.title}
-                    </h2>
-                    <span className="text-sm font-medium text-[#ffaa06]">
-                      {budgetLabel(listing.budget)}
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-4 text-sm text-[#7a5c36]">
-                    <span>Tür: {listing.genre}</span>
-                    <span>
-                      Oluşturuldu: {dateFormatter.format(new Date(listing.created_at))}
-                    </span>
-                    <span>Son teslim: {formatDeadline(listing.deadline)}</span>
-                    {listing.source === 'request' ? (
+            {listings.map((listing) => {
+              const badge = getListingBadge(listing);
+              const statusLabel = getListingStatusLabel(listing.status);
 
-                      <span className="text-xs uppercase tracking-wide text-[#a38d6d]">
-                        {getListingBadge(listing)}
+              return (
+                <li key={listing.id}>
+                  <Link
+                    href={`/dashboard/producer/listings/${listing.id}`}
+                    className="block p-4 bg-white border rounded-lg shadow-sm space-y-2 hover:border-[#0e5b4a] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0e5b4a]"
+                  >
+                    <div className="flex items-center justify-between gap-4">
+                      <h2 className="text-lg font-semibold text-[#0e5b4a]">
+                        {listing.title}
+                      </h2>
+                      <span className="text-sm font-medium text-[#ffaa06]">
+                        {budgetLabel(listing.budget)}
                       </span>
-                    ) : null}
-                  </div>
-                  {listing.description ? (
-                    <p className="text-sm text-[#4f3d2a]">{listing.description}</p>
-                  ) : (
-                    <p className="text-sm text-[#a38d6d]">Açıklama bulunamadı.</p>
-                  )}
-                </Link>
-              </li>
-            ))}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-4 text-sm text-[#7a5c36]">
+                      <span>Tür: {listing.genre}</span>
+                      <span>
+                        Oluşturuldu: {dateFormatter.format(new Date(listing.created_at))}
+                      </span>
+                      <span>Son teslim: {formatDeadline(listing.deadline)}</span>
+                      {badge || statusLabel ? (
+                        <div className="flex items-center gap-2 text-xs">
+                          {badge ? (
+                            <span className="uppercase tracking-wide text-[#a38d6d]">
+                              {badge}
+                            </span>
+                          ) : null}
+                          {statusLabel ? (
+                            <span className="rounded-full bg-[#f4ede3] px-2 py-0.5 text-[0.7rem] font-medium normal-case text-[#7a5c36]">
+                              {statusLabel}
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+                    {listing.description ? (
+                      <p className="text-sm text-[#4f3d2a]">{listing.description}</p>
+                    ) : (
+                      <p className="text-sm text-[#a38d6d]">Açıklama bulunamadı.</p>
+                    )}
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/lib/listings.ts
+++ b/lib/listings.ts
@@ -1,0 +1,36 @@
+import type { ListingSource, VListingUnifiedStatus } from '@/types/db';
+
+export const getListingSourceLabel = (
+  source: ListingSource | string | null | undefined
+): string | null => {
+  if (source === 'request') {
+    return 'Talep';
+  }
+
+  if (source === 'producer' || source === 'producer_listing') {
+    return 'Yapımcı İlanı';
+  }
+
+  return null;
+};
+
+export const getListingStatusLabel = (
+  status: VListingUnifiedStatus | string | null | undefined
+): string | null => {
+  if (!status) {
+    return null;
+  }
+
+  const normalized = String(status).toLowerCase();
+
+  switch (normalized) {
+    case 'open':
+      return 'Açık';
+    case 'closed':
+      return 'Kapalı';
+    case 'draft':
+      return 'Taslak';
+    default:
+      return String(status);
+  }
+};

--- a/supabase/migrations/20240722000000_update_v_listings_unified.sql
+++ b/supabase/migrations/20240722000000_update_v_listings_unified.sql
@@ -13,7 +13,7 @@ SELECT
   l.created_at,
   l.deadline,
   'open'::text AS status,
-  'producer_listing'::text AS source
+  'producer'::text AS source
 FROM public.producer_listings l
 UNION ALL
 SELECT

--- a/types/db.ts
+++ b/types/db.ts
@@ -44,7 +44,7 @@ export interface ProducerInterestNotificationPayload {
   producer_id: string;
 }
 
-export type ListingSource = 'producer_listing' | 'request';
+export type ListingSource = 'producer' | 'request';
 
 export type VListingUnifiedStatus = 'open' | 'closed' | 'draft' | string;
 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -38,4 +38,5 @@ export interface SupabaseApplicationRow {
   listing: SupabaseApplicationListing | null;
   writer: SupabaseApplicationWriter | null;
   conversations: SupabaseApplicationConversation[] | null;
+  conversation_id?: string | null;
 }


### PR DESCRIPTION
## Summary
- centralize listing source and status labelling helpers and use them across producer dashboards
- normalize unified listing source values to "producer" in types and view definition
- show badges for all producer listings and display localized source labels in listings and applications views

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfa87a9c98832d8377e44bb7d61acc