### PR TITLE
Update listing badge helper to respect listing source

### DIFF
--- a/app/dashboard/producer/listings/page.tsx
+++ b/app/dashboard/producer/listings/page.tsx
@@ -31,17 +31,18 @@ const formatDeadline = (deadline: string | null | undefined) => {
 };
 
 const getListingBadge = (listing: VListingUnified) => {
-  const listingType = listing.status ?? listing.source;
+  const source = listing?.source ?? null;
 
-  if (listingType === 'request') {
-    return 'Talep';
+  switch (source) {
+    case 'request':
+      return 'Talep';
+    case 'producer':
+      return 'Yapımcı İlanı';
+    case 'external':
+      return 'Harici Kaynak';
+    default:
+      return null;
   }
-
-  if (listingType === 'producer') {
-    return 'Yapımcı İlanı';
-  }
-
-  return null;
 };
 
 const normalizeListing = (row: any): VListingUnified => {


### PR DESCRIPTION
## Summary
- update the listing badge helper to switch on the listing source with null safety
- add labels for known sources and a graceful fallback for unknown ones

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb0c7e650832d80431c4293c37889