### PR TITLE
Fix producer interest RPC parameter name

### DIFF
--- a/__tests__/producer-browse-page.test.tsx
+++ b/__tests__/producer-browse-page.test.tsx
@@ -125,7 +125,7 @@ describe('BrowseScriptsPage interest handling', () => {
     );
 
     expect(supabase.rpc).toHaveBeenCalledWith('rpc_mark_interest', {
-      p_script_id: baseScript.id,
+      script_id: baseScript.id,
     });
     expect(supabase.rpc).toHaveBeenCalledWith('enqueue_notification', {
       recipient_id: baseScript.owner_id,
@@ -164,7 +164,7 @@ describe('BrowseScriptsPage interest handling', () => {
     );
 
     expect(supabase.rpc).toHaveBeenCalledWith('rpc_mark_interest', {
-      p_script_id: baseScript.id,
+      script_id: baseScript.id,
     });
   });
 
@@ -249,7 +249,7 @@ describe('BrowseScriptsPage interest handling', () => {
     );
 
     expect(supabase.rpc).toHaveBeenCalledWith('rpc_mark_interest', {
-      p_script_id: baseScript.id,
+      script_id: baseScript.id,
     });
     expect(supabase.rpc).toHaveBeenCalledWith('enqueue_notification', {
       recipient_id: baseScript.owner_id,
@@ -286,7 +286,7 @@ describe('BrowseScriptsPage interest handling', () => {
     );
 
     expect(supabase.rpc).toHaveBeenCalledWith('rpc_mark_interest', {
-      p_script_id: baseScript.id,
+      script_id: baseScript.id,
     });
     expect(supabase.rpc).not.toHaveBeenCalledWith('enqueue_notification', expect.anything());
   });

--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -304,7 +304,7 @@ export default function BrowseScriptsPage() {
         const { error: markInterestError } = await supabase.rpc(
           'rpc_mark_interest',
           {
-            p_script_id: script.id,
+            script_id: script.id,
           }
         );
 


### PR DESCRIPTION
## Summary
- update the producer browse page to call rpc_mark_interest with script_id matching the SQL signature
- align unit test expectations with the new RPC payload shape

## Testing
- npm test -- producer-browse

------
https://chatgpt.com/codex/tasks/task_e_68dfcbb19974832d9d8e27c0f4c4cadc