### PR TITLE
Drop rpc_mark_interest before recreating with p_script_id

### DIFF
--- a/sql/migrations/refresh_rpc_mark_interest.sql
+++ b/sql/migrations/refresh_rpc_mark_interest.sql
@@ -1,0 +1,36 @@
+drop function if exists public.rpc_mark_interest(uuid);
+
+create or replace function public.rpc_mark_interest(p_script_id uuid)
+returns public.interests
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_producer uuid;
+  v_interest public.interests%rowtype;
+begin
+  v_producer := auth.uid();
+
+  if v_producer is null then
+    raise exception 'Authentication required' using errcode = 'P0001';
+  end if;
+
+  insert into public.interests (producer_id, script_id)
+  values (v_producer, p_script_id)
+  on conflict (producer_id, script_id) do nothing;
+
+  select *
+  into v_interest
+  from public.interests
+  where producer_id = v_producer
+    and script_id = p_script_id;
+
+  return v_interest;
+end;
+$$;
+
+grant execute on function public.rpc_mark_interest(uuid) to authenticated;
+grant execute on function public.rpc_mark_interest(uuid) to service_role;
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20240722000000_refresh_rpc_mark_interest.sql
+++ b/supabase/migrations/20240722000000_refresh_rpc_mark_interest.sql
@@ -1,0 +1,38 @@
+drop function if exists public.rpc_mark_interest(uuid);
+
+create or replace function public.rpc_mark_interest(p_script_id uuid)
+returns public.interests
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_producer uuid;
+  v_interest public.interests%rowtype;
+begin
+  v_producer := auth.uid();
+
+  if v_producer is null then
+    raise exception 'Authentication required' using errcode = 'P0001';
+  end if;
+
+  insert into public.interests (producer_id, script_id)
+  values (v_producer, p_script_id)
+  on conflict (producer_id, script_id) do nothing;
+
+  select *
+  into v_interest
+  from public.interests
+  where producer_id = v_producer
+    and script_id = p_script_id;
+
+  return v_interest;
+end;
+$$;
+
+-- Make the function available to clients
+grant execute on function public.rpc_mark_interest(uuid) to authenticated;
+grant execute on function public.rpc_mark_interest(uuid) to service_role;
+
+-- Ask PostgREST to reload the schema cache so the function becomes immediately available
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20240722001000_fix_rpc_mark_interest_parameter.sql
+++ b/supabase/migrations/20240722001000_fix_rpc_mark_interest_parameter.sql
@@ -1,0 +1,38 @@
+drop function if exists public.rpc_mark_interest(uuid);
+
+create or replace function public.rpc_mark_interest(p_script_id uuid)
+returns public.interests
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_producer uuid;
+  v_interest public.interests%rowtype;
+begin
+  v_producer := auth.uid();
+
+  if v_producer is null then
+    raise exception 'Authentication required' using errcode = 'P0001';
+  end if;
+
+  insert into public.interests (producer_id, script_id)
+  values (v_producer, p_script_id)
+  on conflict (producer_id, script_id) do nothing;
+
+  select *
+  into v_interest
+  from public.interests
+  where producer_id = v_producer
+    and script_id = p_script_id;
+
+  return v_interest;
+end;
+$$;
+
+-- Make the function available to clients
+grant execute on function public.rpc_mark_interest(uuid) to authenticated;
+grant execute on function public.rpc_mark_interest(uuid) to service_role;
+
+-- Ask PostgREST to reload the schema cache so the function becomes immediately available
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- drop the existing rpc_mark_interest function before recreating it so the parameter rename can succeed
- update the Supabase migration and SQL Editor scripts to rely on the unambiguous p_script_id argument

## Testing
- npm test -- --runTestsByPath __tests__/producer-browse-page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4d2664d90832d8c82dbc6c5a7603c