### PR TITLE
Align rpc_mark_interest RPC with producer UI

### DIFF
--- a/app/dashboard/producer/browse/page.tsx
+++ b/app/dashboard/producer/browse/page.tsx
@@ -273,7 +273,14 @@ export default function BrowseScriptsPage() {
   };
 
   const handleInterest = useCallback(
-    async (script: Script) => {
+    async (scriptId: string) => {
+      const script = scripts.find((item) => item.id === scriptId);
+
+      if (!script) {
+        showToast('error', 'Senaryo bilgisine ulaşılamadı.');
+        return;
+      }
+
       setPendingInterestId(script.id);
       try {
         if (!supabase) {
@@ -349,7 +356,7 @@ export default function BrowseScriptsPage() {
         setPendingInterestId(null);
       }
     },
-    [notifyWriterOfInterest, showToast, supabase]
+    [notifyWriterOfInterest, scripts, showToast, supabase]
   );
 
   return (
@@ -542,7 +549,7 @@ export default function BrowseScriptsPage() {
                   >
                     <button
                       className="btn btn-primary"
-                      onClick={() => handleInterest(s)}
+                      onClick={() => handleInterest(s.id)}
                       disabled={pendingInterestId === s.id}
                       aria-busy={pendingInterestId === s.id}
                     >

--- a/supabase/migrations/20240725090000_update_rpc_mark_interest.sql
+++ b/supabase/migrations/20240725090000_update_rpc_mark_interest.sql
@@ -1,0 +1,14 @@
+-- Align rpc_mark_interest with current frontend usage
+create or replace function public.rpc_mark_interest(script_id uuid)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.interests (producer_id, script_id, created_at)
+  values (auth.uid(), script_id, now())
+  on conflict (producer_id, script_id) do nothing;
+end;
+$$;
+
+grant execute on function public.rpc_mark_interest(uuid) to anon, authenticated;


### PR DESCRIPTION
## Summary
- add a migration that redefines `rpc_mark_interest` with the expected signature, idempotent insert, and grants for anon and authenticated roles
- update the producer browse page to call the RPC using the `script_id` argument while preserving the existing UX for notifications and toasts

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a012068c4832da7044a430a10d338)